### PR TITLE
md_inputs is sent on each forward query

### DIFF
--- a/folding/miners/folding_miner.py
+++ b/folding/miners/folding_miner.py
@@ -281,25 +281,26 @@ class FoldingMiner(BaseMinerNeuron):
 
             # We will attempt to read the state of the simulation from the state file
             state_file = os.path.join(output_dir, f"{synapse.pdb_id}_state.txt")
-            if os.path.exists(state_file):
+
+            # Open the state file that should be generated during the simulation.
+            try:
                 with open(state_file, "r") as f:
                     lines = f.readlines()
                     state = lines[-1].strip()
-                    state = (
-                        "md_0_1" if state == "finished" else state
-                    )  # if no lines then we will try to find md_0_1 files
+                    state = "md_0_1" if state == "finished" else state
 
-            bt.logging.warning(f"❗ Found existing data for protein: {synapse.pdb_id} ❗")
-            synapse = attach_files_to_synapse(
-                synapse=synapse, data_directory=output_dir, state=state
-            )
+                bt.logging.warning(
+                    f"❗ Found existing data for protein: {synapse.pdb_id} ❗"
+                )
+                synapse = attach_files_to_synapse(
+                    synapse=synapse, data_directory=output_dir, state=state
+                )
+            except Exception as e:
+                bt.logging.error(
+                    f"Failed to read state file for protein {synapse.pdb_id} with error: {e}"
+                )
 
-            if len(synapse.md_output) == 0:
-                return synapse
-
-            return check_synapse(
-                synapse=synapse
-            )  # remove md_inputs, they will be there in this stage.
+            return check_synapse(synapse=synapse)
 
         # Check if the number of active processes is less than the number of CPUs
         if len(self.simulations) >= self.max_workers:

--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -201,7 +201,7 @@ def add_args(cls, parser):
         "--mdrun_args.maxh",
         type=str,
         help="Timeout for the mdrun simulation in seconds (each step).",
-        default=7200,  # default is 2h.
+        default=21600,  # default is 6h.
     )
 
 

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -77,16 +77,15 @@ class Protein:
 
     @staticmethod
     def from_job(job: Job, config: Dict):
-        # A nuance of the job loader: only load the md_inputs if the job has not been updated.
         bt.logging.warning(f"sampling pdb job {job.pdb}")
-        load_md_inputs = True if job.updated_count == 0 else False
+        # Load_md_inputs is set to True to ensure that miners get files every query.
         return Protein(
             pdb_id=job.pdb,
             ff=job.ff,
             box=job.box,
             water=job.water,
             config=config,
-            load_md_inputs=load_md_inputs,
+            load_md_inputs=True,
         )
 
     def gather_pdb_id(self):

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -79,7 +79,6 @@ class Validator(BaseValidatorNeuron):
             job (Job): Job object containing the pdb and hotkeys
         """
 
-        # TODO: the command below should correctly prepare the md_inputs to point at the current best gro files (+ others)
         protein = Protein.from_job(job=job, config=self.config.protein)
 
         uids = [self.metagraph.hotkeys.index(hotkey) for hotkey in job.hotkeys]


### PR DESCRIPTION
This PR ensures that we do not preferentially add files to the `md_inputs`, but rather do it each time we call the protein class from the `from_job` method. This is to enable miners to start a simulation even if they miss the first submission.  