### PR TITLE
Fix miner weighting, and logging

### DIFF
--- a/folding/base/miner.py
+++ b/folding/base/miner.py
@@ -111,10 +111,7 @@ class BaseMinerNeuron(BaseNeuron):
         try:
             while not self.should_exit:
                 time.sleep(10)
-
-                # Sync metagraph and potentially set weights.
                 self.sync()
-                self.step += 1
 
         # If someone intentionally stops the miner, it'll safely terminate operations.
         except KeyboardInterrupt:
@@ -179,3 +176,6 @@ class BaseMinerNeuron(BaseNeuron):
 
         # Sync the metagraph.
         self.metagraph.sync(subtensor=self.subtensor)
+
+    def set_weights(self):
+        pass

--- a/folding/base/neuron.py
+++ b/folding/base/neuron.py
@@ -163,9 +163,7 @@ class BaseNeuron(ABC):
         ) > self.config.neuron.epoch_length
 
     def save_state(self):
-        bt.logging.warning(
-            "save_state() not implemented for this neuron. You can implement this function to save model checkpoints or other useful data."
-        )
+        pass
 
     def load_state(self):
         bt.logging.warning(

--- a/folding/miners/folding_miner.py
+++ b/folding/miners/folding_miner.py
@@ -237,6 +237,9 @@ class FoldingMiner(BaseMinerNeuron):
             FoldingSynapse: synapse with md_output attached
         """
 
+        # increment step counter everytime miner receives a query.
+        self.step += 1
+
         if len(self.simulations) > 0:
             bt.logging.warning(f"Simulations Running: {list(self.simulations.keys())}")
 

--- a/folding/miners/folding_miner.py
+++ b/folding/miners/folding_miner.py
@@ -2,12 +2,9 @@ import os
 import time
 import glob
 import base64
-import psutil
 import concurrent.futures
 from typing import Dict, List, Tuple
 from collections import defaultdict
-from dataclasses import dataclass
-import traceback
 import bittensor as bt
 
 # import base miner class which takes care of most of the boilerplate
@@ -16,6 +13,7 @@ from folding.protocol import FoldingSynapse
 from folding.utils.ops import (
     run_cmd_commands,
     check_if_directory_exists,
+    get_tracebacks,
 )
 
 # root level directory for the project (I HATE THIS)
@@ -56,6 +54,7 @@ def compute_intermediate_gro(
         return True
     except Exception as E:
         bt.logging.error(f"Error running intermediate gro: {E}")
+        get_tracebacks()
         return False
 
 
@@ -71,6 +70,7 @@ def attach_files(files_to_attach: List, synapse: FoldingSynapse) -> FoldingSynap
                 synapse.md_output[filename] = base64.b64encode(f.read())
         except Exception as e:
             bt.logging.error(f"Failed to read file {filename!r} with error: {e}")
+            get_tracebacks()
 
     return synapse
 
@@ -156,6 +156,7 @@ def attach_files_to_synapse(
         bt.logging.error(
             f"Failed to attach files for pdb {synapse.pdb_id} with error: {e}"
         )
+        get_tracebacks()
         synapse.md_output = {}
         # TODO Maybe in this point in the logic it makes sense to try and restart the sim.
 
@@ -193,7 +194,7 @@ class FoldingMiner(BaseMinerNeuron):
         )  # Maps pdb_ids to the current state of the simulation
 
         self.max_workers = self.config.neuron.max_workers
-        bt.logging.debug(
+        bt.logging.warning(
             f"🚀 Starting FoldingMiner that handles {self.max_workers} workers 🚀"
         )
 

--- a/folding/utils/ops.py
+++ b/folding/utils/ops.py
@@ -1,10 +1,12 @@
 import os
 import re
+import sys
 import tqdm
 import shutil
 import random
-import subprocess
 import hashlib
+import subprocess
+import traceback
 import pickle as pkl
 
 from typing import List, Dict
@@ -117,6 +119,16 @@ def check_if_directory_exists(output_directory):
         bt.logging.debug(f"Created directory {output_directory!r}")
 
 
+def get_tracebacks():
+    """A generic traceback function obtain the traceback details of an exception."""
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    formatted_traceback = traceback.format_exception(exc_type, exc_value, exc_traceback)
+
+    bt.logging.error(" ---------------- Traceback details ---------------- ")
+    bt.logging.warning("".join(formatted_traceback))
+    bt.logging.warning(" ---------------- End of Traceback ----------------\n")
+
+
 def run_cmd_commands(
     commands: List[str], suppress_cmd_output: bool = True, verbose: bool = False
 ):
@@ -139,6 +151,7 @@ def run_cmd_commands(
             if verbose:
                 bt.logging.error(f"Output: {e.stdout.decode()}")
                 bt.logging.error(f"Error: {e.stderr.decode()}")
+                get_tracebacks()
             raise
 
 


### PR DESCRIPTION
Miners currently try and set weights, and this is because many of the miners on the network have validator permits (early days without many valis with high stake on the network). Because of this, it can cause miners to die and have to restart in pm2, causing child processes not to die properly. Therefore, we add this as a method to `pass` . 

we also add better logging through a `get_tracebacks` function now in `folding/ops`. 

Miner step is now only increased when the forward method is called (ie, only when they receive queries from validators)