### PR TITLE
Features/seed

### DIFF
--- a/data/emin.mdp
+++ b/data/emin.mdp
@@ -6,6 +6,9 @@ emtol       = 1000.0 ; Stop minimization when the maximum force < 1000.0 kJ/mol/
 emstep      = 0.01   ; Minimization step size
 nstenergy   = 500    ; save energies every 1.0 ps, so we can observe if we are successful
 nsteps      = 100     ; run as long as we need
+ld-seed     = -1;
+continuation = no ;
+
 ; Settings that make sure we run with parameters in harmony with the selected force-field
 constraints             = h-bonds   ; bonds involving H are constrained
 rcoulomb                = 1.2       ; short-range electrostatic cutoff (in nm)

--- a/data/emin_charmm.mdp
+++ b/data/emin_charmm.mdp
@@ -6,6 +6,9 @@ emtol       = 1000.0 ; Stop minimization when the maximum force < 1000.0 kJ/mol/
 emstep      = 0.01   ; Minimization step size
 nstenergy   = 500    ; save energies every 1.0 ps, so we can observe if we are successful
 nsteps      = 100     ; run as long as we need
+ld-seed     = -1;
+continuation = no ;
+
 ; Settings that make sure we run with parameters in harmony with the selected force-field
 constraints             = h-bonds   ; bonds involving H are constrained
 rcoulomb                = 1.2       ; short-range electrostatic cutoff (in nm)

--- a/data/md.mdp
+++ b/data/md.mdp
@@ -21,6 +21,7 @@ nstlog                   = 50    ; for writing energies to log file
 nstenergy                = 500     ; for writing energies to edr file 
 ; Output frequency and precision for .xtc file
 nstxout-compressed       = 2500    ; for writing coords (x) 
+ld-seed     = -1;
 
 ; Pressure coupling is on
 pcoupl                  = C-rescale               ; Pressure coupling on in NPT

--- a/data/md_charmm.mdp
+++ b/data/md_charmm.mdp
@@ -20,6 +20,7 @@ nstlog                   = 50    ; for writing energies to log file
 nstenergy                = 500     ; for writing energies to edr file 
 ; Output frequency and precision for .xtc file
 nstxout-compressed       = 2500    ; for writing coords (x) 
+ld-seed     = -1;
 
 ; Pressure coupling is on
 pcoupl                  = C-rescale               ; Pressure coupling on in NPT

--- a/data/npt.mdp
+++ b/data/npt.mdp
@@ -13,6 +13,7 @@ nstlog                  = 50
 pbc                     = xyz       ;
 
 continuation            = yes      
+ld-seed                 = -1        ;
 
 ; Pressure coupling is on
 pcoupl                  = C-rescale             ; Pressure coupling on in NPT

--- a/data/npt_charmm.mdp
+++ b/data/npt_charmm.mdp
@@ -13,6 +13,7 @@ nstlog                  = 50
 pbc                     = xyz       ;
 
 continuation            = yes      
+ld-seed                 = -1
 
 ; Pressure coupling is on
 pcoupl                  = C-rescale             ; Pressure coupling on in NPT

--- a/data/nvt.mdp
+++ b/data/nvt.mdp
@@ -11,6 +11,8 @@ nstlog                  = 50
 
 ; periodic boundary condition
 pbc                     = xyz       ;
+continuation            = no 
+ld-seed                 = -1
 
 ; Keep system temperature fluctuating physically correct
 tcoupl                  = V-rescale           ; modified Berendsen thermostat
@@ -24,6 +26,7 @@ pcoupl                  = no
 ; Velocity generation
 gen_vel                 = yes                 ; assign velocities from Maxwell distribution
 gen_temp                = 300                 ; temperature for Maxwell distribution
+gen_seed                = -1                  ;
 
 ; Output frequency and precision for .xtc file
 nstxout-compressed       = 2500    ; for writing coords (x) 

--- a/data/nvt_charmm.mdp
+++ b/data/nvt_charmm.mdp
@@ -11,6 +11,7 @@ nstlog                  = 50
 
 ; periodic boundary condition
 pbc                     = xyz       ;
+ld-seed = -1;
 
 ; Keep system temperature fluctuating physically correct
 tcoupl                  = V-rescale           ; modified Berendsen thermostat
@@ -19,12 +20,13 @@ tau_t                   = 1.0      ; time constant, in ps
 ref_t                   = 300      ; reference temperature, one for each group, in K
 
 ; Pressure coupling is off
-pcoupl                  = no
+pcoupl                  = no ;
+continuation            = no ;
 
 ; Velocity generation
 gen_vel                 = yes                 ; assign velocities from Maxwell distribution
 gen_temp                = 300                 ; temperature for Maxwell distribution
-
+gen_seed                = -1
 ; Output frequency and precision for .xtc file
 nstxout-compressed       = 2500    ; for writing coords (x) 
 


### PR DESCRIPTION
This PR ensures that the same seed is set for all `.mdp` files on the validator side. 
- First, all of the `.mdp` files were edited to include `ld-seed` nd `gen_seed` if they did not already. 
- Next I edit the `mdp_files` list to include all of the `.mdp` files as well as updating the `params_to_change` list. 
- Create a gen_seed method in the protein class.
- update the `edit_files` method to include two new arguments `param_name` and `seed`
- edit `Protein.forward()` to create an instance of `gen_seed` and pass it to `edit_files` each time it is called. 
- Update the forward to call `edit_files` for each `pram_name` 