### PR TITLE
Hotfix/thruput

### DIFF
--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -233,7 +233,7 @@ def add_miner_args(cls, parser):
         "--neuron.max_workers",
         type=int,
         help="Total number of subprocess that the miner is designed to run.",
-        default=4,
+        default=8,
     )
 
     parser.add_argument(

--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -279,14 +279,14 @@ def add_validator_args(cls, parser):
         "--neuron.timeout",
         type=float,
         help="The timeout for each forward call. (seconds)",
-        default=120,
+        default=30,
     )
 
     parser.add_argument(
         "--neuron.update_interval",
         type=float,
         help="The interval in which the validators query the miners for updates. (seconds)",
-        default=180,  # samples every 3-minutes in the simulation.
+        default=300,  # samples every 5-minutes in the simulation.
     )
 
     parser.add_argument(
@@ -300,7 +300,7 @@ def add_validator_args(cls, parser):
         "--neuron.queue_size",
         type=int,
         help="The number of jobs to keep in the queue.",
-        default=4,
+        default=10,
     )
 
     parser.add_argument(

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -396,6 +396,9 @@ class Protein:
             md_output (Dict): dictionary of information from the miner.
         """
 
+        # Make times to 1 decimal place for gromacs stability.
+        simulation_step_time = round(simulation_step_time, 1)
+
         gro_file_location = os.path.join(output_directory, "intermediate.gro")
         tpr_file = os.path.join(output_directory, md_outputs_exts["tpr"])
         xtc_file = os.path.join(output_directory, md_outputs_exts["xtc"])

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -206,7 +206,7 @@ class Protein:
 
     def calculate_params_save_interval(self):
         # TODO Define what this function should do. Placeholder for now.
-        return 100  # save every 100 steps
+        return 500  # save every 100 steps
 
     def check_configuration_file_commands(self) -> List[str]:
         """
@@ -271,7 +271,7 @@ class Protein:
             f"gmx grompp -f {self.pdb_directory}/emin.mdp -c solv_ions.gro -p topol.top -o em.tpr",
             "gmx mdrun -v -deffnm em",
         ]
-        
+
         run_cmd_commands(
             commands=commands, suppress_cmd_output=self.config.suppress_cmd_output
         )

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,8 @@ make
 make check
 make install
 
+echo "source /usr/local/gromacs/bin/GMXRC" >> ~/.bashrc
+
 # Add GROMACS initialization to venv/bin/activate
 COMMAND="source /usr/local/gromacs/bin/GMXRC"
 cd ../..


### PR DESCRIPTION
This PR includes the following upgrades: 

## Gromacs Versioning
Validators are unstable because their gromacs versioning is incorrect. To fix this, we need to make sure that gromacs is being added to the bashrc properly. We update the install.sh script to do this. 

## Validator / miner throughput
- There is a major problem with incentive and emissions. It is partially because of the above gromacs mis-match leading to gromacs bugs, but also the throughput of the network is very low. We need to increase this to try and sample uids better. As such, we include the following changes:
1. Decrease miner timeout to 30s. Over 90% of the network responds < 30s. See plot below. 
<img width="1005" alt="image" src="https://github.com/macrocosm-os/folding/assets/83707037/e4837ba3-b0a4-4fb0-9b45-f766fc336811">

2. Increase the minimum sampling interval from 100 steps to 500. This will help save miner storage. 
3. In conjunction with point 2, we _increase_ the time interval between queries from 3 minutes to 5 minutes. 
4. We also increase the default queue size for validators from 4 to 10. 
5. Along with this, we increase the max_workers from 4 to 8 for miners.
6. Edit the timestep that is looked at by validators. 

The changes come from the following assumed relationship: 
```
import numpy as np 
import pandas as pd 
import plotly.express as px 
 
num_validators = 7 
num_jobs = np.arange(2, 13)

num_miners = (256 //2)
jobs_per_miner = 4

number_of_total_network_jobs = num_miners * jobs_per_miner #num miners * assumed number of jobs per miner
factor = number_of_total_network_jobs / num_validators

num_uids_per_job = factor // num_jobs

df = pd.DataFrame() 
df['num_uids_per_job'] = num_uids_per_job
df['num_jobs'] = num_jobs

px.line(df, x='num_jobs', y='num_uids_per_job', 
        template = 'plotly_white', 
        height = 600, 
        title=f'Number of UIDs per Job vs Number of Jobs, assuming {num_miners} miners * {jobs_per_miner} miners jobs (total network jobs)', markers=True)
   ```

<img width="1436" alt="image" src="https://github.com/macrocosm-os/folding/assets/83707037/4250ba09-33f8-4f31-913e-ed716a7bb0cb">

We want to be on the right side of the curve to ensure that miners are busy