### PR TITLE
Features/miner timeout

### DIFF
--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -244,6 +244,13 @@ def add_miner_args(cls, parser):
     )
 
     parser.add_argument(
+        "--neuron.query_timeout",
+        type=float,
+        default=1800,
+        help="Remove protein jobs that havent been queried within the query timeout.",
+    )
+
+    parser.add_argument(
         "--blacklist.force_validator_permit",
         action="store_true",
         help="If set, we will force incoming requests to have a permit.",


### PR DESCRIPTION
Adds a new parameter to the config to control the timeout for simulations that are no longer being queried for. 
- If a validator is no longer querying for a specific pdb, this ensures that miners (non-winners) still running the simulation will remove this pdb from the execution stack. 
- This could happen if the winning miner is much faster than others, therefore their simulation is completed and files can be sent to the vaildator but the other miners are still running the simulation. 