### PR TITLE
Improve Makefile to Dynamically Determine Number of Physical Cores

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,17 @@ apt-get update
 apt-get install build-essential cmake libfftw3-dev vim npm -y
 npm install -g pm2 -y
 
+# Determine the number of physical cores
+if [ "$(uname)" == "Linux" ]; then
+    NUM_CORES=$(lscpu | grep "^Core(s) per socket:" | awk '{print $4}')
+    NUM_SOCKETS=$(lscpu | grep "^Socket(s):" | awk '{print $2}')
+    NUM_PHYSICAL_CORES=$((NUM_CORES * NUM_SOCKETS))
+elif [ "$(uname)" == "Darwin" ]; then
+    NUM_PHYSICAL_CORES=$(sysctl -n hw.physicalcpu)
+else
+    NUM_PHYSICAL_CORES=10
+fi
+
 # download and unpack gromacs
 wget ftp://ftp.gromacs.org/gromacs/gromacs-2024.1.tar.gz
 tar xfz gromacs-2024.1.tar.gz
@@ -15,7 +26,7 @@ cd gromacs-2024.1
 mkdir build
 cd build
 cmake .. -DGMX_BUILD_OWN_FFTW=ON -DREGRESSIONTEST_DOWNLOAD=ON
-make
+make -j$NUM_PHYSICAL_CORES
 make check
 make install
 


### PR DESCRIPTION
This PR enhances the GROMACS build script to dynamically determine the number of physical CPU cores on the system and use this value for the make -j command. This ensures optimal utilization of system resources across different machines without manual adjustment.