### PR TITLE
Made epsilon change in relation to the protein complexity

### DIFF
--- a/folding/store.py
+++ b/folding/store.py
@@ -111,7 +111,8 @@ class PandasJobStore:
             hotkeys=hotkeys,
             created_at=pd.Timestamp.now().floor("s"),
             updated_at=pd.Timestamp.now().floor("s"),
-            epsilon=epsilon**kwargs,
+            epsilon=epsilon,
+            **kwargs,
         ).to_frame()
 
         if len(self._db) == 0:

--- a/folding/store.py
+++ b/folding/store.py
@@ -148,6 +148,7 @@ class Job:
     max_time_no_improvement: pd.Timedelta = pd.Timedelta(minutes=60)
     min_updates: int = 10
     event: dict = None
+    epsilon: float = 1e2
 
     def to_dict(self):
         return asdict(self)
@@ -170,8 +171,8 @@ class Job:
         self.updated_count += 1
 
         # TODO: make epsilon a param, or a class attrib
-        epsilon = 1e2
-        if loss < self.best_loss - epsilon:
+        # epsilon = 1e2
+        if loss < self.best_loss - self.epsilon:
             self.best_loss = loss
             self.best_loss_at = pd.Timestamp.now().floor("s")
             self.best_hotkey = hotkey

--- a/folding/store.py
+++ b/folding/store.py
@@ -89,7 +89,14 @@ class PandasJobStore:
         return queue
 
     def insert(
-        self, pdb: str, ff: str, box: str, water: str, hotkeys: List[str], epsilon: float, **kwargs
+        self,
+        pdb: str,
+        ff: str,
+        box: str,
+        water: str,
+        hotkeys: List[str],
+        epsilon: float,
+        **kwargs,
     ):
         """Adds a new job to the database."""
 
@@ -104,8 +111,7 @@ class PandasJobStore:
             hotkeys=hotkeys,
             created_at=pd.Timestamp.now().floor("s"),
             updated_at=pd.Timestamp.now().floor("s"),
-            epsilon=epsilon
-            **kwargs,
+            epsilon=epsilon**kwargs,
         ).to_frame()
 
         if len(self._db) == 0:
@@ -148,7 +154,7 @@ class Job:
     updated_count: int = 0
     max_time_no_improvement: pd.Timedelta = pd.Timedelta(minutes=60)
     min_updates: int = 10
-    epsilon: float = 1e2
+    epsilon: float = 5e3
     event: dict = None
 
     def to_dict(self):

--- a/folding/store.py
+++ b/folding/store.py
@@ -89,7 +89,7 @@ class PandasJobStore:
         return queue
 
     def insert(
-        self, pdb: str, ff: str, box: str, water: str, hotkeys: List[str], **kwargs
+        self, pdb: str, ff: str, box: str, water: str, hotkeys: List[str], epsilon: float, **kwargs
     ):
         """Adds a new job to the database."""
 
@@ -104,6 +104,7 @@ class PandasJobStore:
             hotkeys=hotkeys,
             created_at=pd.Timestamp.now().floor("s"),
             updated_at=pd.Timestamp.now().floor("s"),
+            epsilon=epsilon
             **kwargs,
         ).to_frame()
 
@@ -147,8 +148,8 @@ class Job:
     updated_count: int = 0
     max_time_no_improvement: pd.Timedelta = pd.Timedelta(minutes=60)
     min_updates: int = 10
-    event: dict = None
     epsilon: float = 1e2
+    event: dict = None
 
     def to_dict(self):
         return asdict(self)
@@ -170,7 +171,6 @@ class Job:
         self.updated_at = pd.Timestamp.now().floor("s")
         self.updated_count += 1
 
-        # TODO: make epsilon a param, or a class attrib
         if loss < self.best_loss - self.epsilon:
             self.best_loss = loss
             self.best_loss_at = pd.Timestamp.now().floor("s")

--- a/folding/store.py
+++ b/folding/store.py
@@ -171,7 +171,6 @@ class Job:
         self.updated_count += 1
 
         # TODO: make epsilon a param, or a class attrib
-        # epsilon = 1e2
         if loss < self.best_loss - self.epsilon:
             self.best_loss = loss
             self.best_loss_at = pd.Timestamp.now().floor("s")

--- a/folding/validators/forward.py
+++ b/folding/validators/forward.py
@@ -159,6 +159,7 @@ def try_prepare_challenge(config, pdb_id: str) -> Dict:
             event["hp_sample_time"] = time.time() - hp_sampler_time
             event["pdb_complexity"] = [dict(protein.pdb_complexity)]
             event["init_energy"] = protein.init_energy
+            event["epsilon"] = protein.epsilon
 
             if "validator_search_status" not in event:
                 bt.logging.warning("✅✅ Simulation ran successfully! ✅✅")

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -232,7 +232,7 @@ class Protein:
         self.init_energy = calc_potential_from_edr(
             output_dir=self.validator_directory, edr_name="em.edr"
         )
-        self.epsilon = self._calculate_epsilon()
+        self._calculate_epsilon()
 
     def __str__(self):
         return f"Protein(pdb_id={self.pdb_id}, ff={self.ff}, box={self.box}"
@@ -543,8 +543,8 @@ class Protein:
         return True
 
     def _calculate_epsilon(self):
-        num_atoms = self.pdb_complexity["ATOM"]
-        if num_atoms > 100:
-            return 7.14819473 * num_atoms + 1.68442317e04
-        else:
-            return 5000
+        if "ATOM" in self.pdb_complexity.keys():
+            num_atoms = self.pdb_complexity["ATOM"]
+
+            if num_atoms > 100:
+                self.epsilon = 7.14819473 * num_atoms + 1.68442317e04

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -72,6 +72,7 @@ class Protein:
         # set to an arbitrarilly high number to ensure that the first miner is always accepted.
         self.init_energy = 0
         self.pdb_complexity = defaultdict(int)
+        self.epsilon = 1e2
 
     def setup_filepaths(self):
         self.pdb_file = f"{self.pdb_id}.pdb"
@@ -94,6 +95,7 @@ class Protein:
             water=job.water,
             config=config,
             load_md_inputs=True,
+            epsilon=job.epsilon
         )
 
         try:
@@ -230,6 +232,7 @@ class Protein:
         self.init_energy = calc_potential_from_edr(
             output_dir=self.validator_directory, edr_name="em.edr"
         )
+        self.epsilon = self._calculate_epsilon()
 
     def __str__(self):
         return f"Protein(pdb_id={self.pdb_id}, ff={self.ff}, box={self.box}"
@@ -538,3 +541,11 @@ class Protein:
             output_directory=output_directory, gro_file_location=gro_file_location
         )
         return True
+    
+    def _calculate_epsilon(self):
+        num_atoms = self.pdb_complexity["ATOM"]
+        if num_atoms>100:
+            return 7.14819473*num_atoms+1.68442317e04
+        else: 
+            return 5000
+        

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -72,7 +72,7 @@ class Protein:
         # set to an arbitrarilly high number to ensure that the first miner is always accepted.
         self.init_energy = 0
         self.pdb_complexity = defaultdict(int)
-        self.epsilon = 1e2
+        self.epsilon = 5e3
 
     def setup_filepaths(self):
         self.pdb_file = f"{self.pdb_id}.pdb"
@@ -95,7 +95,7 @@ class Protein:
             water=job.water,
             config=config,
             load_md_inputs=True,
-            epsilon=job.epsilon
+            epsilon=job.epsilon,
         )
 
         try:
@@ -541,11 +541,10 @@ class Protein:
             output_directory=output_directory, gro_file_location=gro_file_location
         )
         return True
-    
+
     def _calculate_epsilon(self):
         num_atoms = self.pdb_complexity["ATOM"]
-        if num_atoms>100:
-            return 7.14819473*num_atoms+1.68442317e04
-        else: 
+        if num_atoms > 100:
+            return 7.14819473 * num_atoms + 1.68442317e04
+        else:
             return 5000
-        

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -143,6 +143,7 @@ class Validator(BaseValidatorNeuron):
                     water=job_event["water"],
                     box=job_event["box"],
                     hotkeys=selected_hotkeys,
+                    epsilon=job_event.epsilon,
                     event=job_event,
                 )
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -143,7 +143,7 @@ class Validator(BaseValidatorNeuron):
                     water=job_event["water"],
                     box=job_event["box"],
                     hotkeys=selected_hotkeys,
-                    epsilon=job_event.epsilon,
+                    epsilon=job_event["epsilon"],
                     event=job_event,
                 )
 


### PR DESCRIPTION
With insights into the data that we've been receiving after the latest update we felt it was needed to finally change epsilon from a simple static number into a variable that actually adapts based on the job. 

After some analysis we found a clear trend between the average change in loss (energy) per miner update and the amount of total atoms in the protein as seen on the following graph:
![change per update vs number of atoms](https://github.com/macrocosm-os/folding/assets/40073601/5d4c1eea-a0d2-418c-9e93-2ff217d17e56)

Note that both axes are in log scale due to the disparity in scale of the data. It is clear that the changes in loss we observe are increasing with the size of the protein. There is a few reasons we can't simply use the trendline seen in the image to model as epsilon:
1. The data we currently possess is extremely noisy due to the instability of the network and hence the standard deviation of the dataset is incredibly high
2. We don't have the time parameter of the simulations, ie we don't know for how long each simulation has been running for. This is important because as simulations converge on the optimal solution their loss will get smaller and smaller.

We decided to take a more conservative approach for now and create a function that will result in an overall lower epsilon, this can be seen in the following graph: 
![change per update vs number of atoms with epsilon trendline](https://github.com/macrocosm-os/folding/assets/40073601/7ab2754e-0697-4ca0-b058-ef3e6c41bf36)

This function was created by going through the normal optimization process but we weighed the points below the trendline more than those above the trendline.

The current epsilon calculation function looks as follows:

`epsilon = 7.14819473 * num_atoms + 1.68442317e04`

We make an exception for molecules below 100 atoms as we do not have enough data for those and set epsilon to a flat 5000