### PR TITLE
change miner rewards

### DIFF
--- a/folding/rewards/reward_pipeline.py
+++ b/folding/rewards/reward_pipeline.py
@@ -1,0 +1,62 @@
+import torch
+from folding.store import Job
+from folding.rewards.linear_reward import divide_decreasing
+
+
+def reward_pipeline(
+    energies: torch.Tensor, rewards: torch.Tensor, top_reward: float, job: Job
+):
+    """A reward pipeline that determines how to place rewards onto the miners sampled within the batch.
+    Currently applies a linearly decreasing reward on all miners that are not the current best / previously
+    best loss using the function "divide_decreasing".
+
+    Args:
+        energies (torch.Tensor): tensor of returned energies
+        rewards (torch.Tensor): tensor of rewards, floats.
+        top_reward (float): upper bound reward.
+        job (Job)
+    """
+    nonzero_energies = torch.nonzero(energies)
+    best_index = job.hotkeys.index(job.best_hotkey)
+
+    # There are cases where the top_miner stops replying. ensure to assign reward.
+    rewards[best_index] = top_reward
+
+    # If no miners reply, we want *all* reward to go to the top miner.
+    if len(nonzero_energies) == 0:
+        rewards[best_index] = 1
+        return rewards
+
+    if (len(nonzero_energies) == 1) and (nonzero_energies[0] == best_index):
+        rewards[best_index] = 1
+        return rewards
+
+    # Find if there are any indicies that are the same as the best value
+    remaining_miners = {}
+    for index in nonzero_energies:
+        # There could be multiple max energies.
+        # The best energy could be the one that is saved in the store.
+        if (energies[index] == job.best_loss) or (index == best_index):
+            rewards[index] = top_reward
+        else:
+            remaining_miners[index] = energies[index]
+
+    # The amount of reward that is distributed to the remaining miners MUST be less than the reward given to the top miners.
+    num_reminaing_miners = len(remaining_miners)
+    if num_reminaing_miners > 1:
+        sorted_remaining_miners = dict(
+            sorted(remaining_miners.items(), key=lambda item: item[1])
+        )  # sort smallest to largest
+
+        # Apply a fixed decrease in reward on the remaining non-zero miners.
+        rewards_per_miner = divide_decreasing(
+            amount_to_distribute=1 - top_reward,
+            number_of_elements=num_reminaing_miners,
+        )
+        for index, r in zip(sorted_remaining_miners.keys(), rewards_per_miner):
+            rewards[index] = r
+    else:
+        for index in remaining_miners.keys():
+            rewards[index] = 1 - top_reward
+
+    return rewards

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -28,7 +28,7 @@ import bittensor as bt
 
 from folding.store import PandasJobStore
 from folding.utils.uids import get_random_uids
-from folding.rewards.linear_reward import divide_decreasing
+from folding.rewards.reward_pipeline import reward_pipeline
 from folding.validators.forward import create_new_challenge, run_step
 from folding.validators.protein import Protein
 
@@ -146,57 +146,6 @@ class Validator(BaseValidatorNeuron):
                     event=job_event,
                 )
 
-    def reward_pipeline(
-        self, energies: torch.Tensor, rewards: torch.Tensor, top_reward: float, job: Job
-    ):
-        """A reward pipeline that determines how to place rewards onto the miners sampled within the batch.
-        Currently applies a linearly decreasing reward on all miners that are not the current best / previously
-        best loss using the function "divide_decreasing".
-
-        Args:
-            energies (torch.Tensor): tensor of returned energies
-            rewards (torch.Tensor): tensor of rewards, floats.
-            top_reward (float): upper bound reward.
-            job (Job)
-        """
-        nonzero_energies = torch.nonzero(energies)
-
-        if len(nonzero_energies) <= 1:
-            rewards[job.hotkeys.index(job.best_hotkey)] = 1
-            return rewards
-
-        # Find if there are any indicies that are the same as the best value
-        remaining_miners = {}
-        for index in nonzero_energies:
-            # There could be multiple max energies.
-            # The best energy could be the one that is saved in the store. We reward this old miner, as they don't need to reply anymore.
-            if (energies[index] == job.best_loss) or (
-                index == job.hotkeys.index(job.best_hotkey)
-            ):
-                rewards[index] = top_reward
-            else:
-                remaining_miners[index] = energies[index]
-
-        # The amount of reward that is distributed to the remaining miners MUST be less than the reward given to the top miners.
-        num_reminaing_miners = len(remaining_miners)
-        if num_reminaing_miners > 1:
-            sorted_remaining_miners = dict(
-                sorted(remaining_miners.items(), key=lambda item: item[1])
-            )  # sort smallest to largest
-
-            # Apply a fixed decrease in reward on the remaining non-zero miners.
-            rewards_per_miner = divide_decreasing(
-                amount_to_distribute=1 - top_reward,
-                number_of_elements=num_reminaing_miners,
-            )
-            for index, r in zip(sorted_remaining_miners.keys(), rewards_per_miner):
-                rewards[index] = r
-        else:
-            for index in remaining_miners.keys():
-                rewards[index] = 1 - top_reward
-
-        return rewards
-
     def update_job(self, job: Job):
         """Updates the job status based on the event information
 
@@ -253,7 +202,7 @@ class Validator(BaseValidatorNeuron):
                 gro_hash=gro_hash,
             )
 
-            rewards: torch.Tensor = self.reward_pipeline(
+            rewards: torch.Tensor = reward_pipeline(
                 energies=energies, rewards=rewards, top_reward=top_reward, job=job
             )
 
@@ -261,6 +210,10 @@ class Validator(BaseValidatorNeuron):
             self.update_scores(
                 rewards=rewards,
                 uids=uids,  # pretty confident these are in the correct order.
+            )
+        else:
+            bt.logging.warning(
+                f"All energies zero for job {job.pdb} and job has never been updated... Skipping"
             )
 
         # Finally, we update the job in the store regardless of what happened.


### PR DESCRIPTION
This PR includes a slightly different formulation of the reward stack. Miners that are competing with no one else, they get 100% of the reward. If the top miner stops replying and no one else is competing, they still get 100% of the reward. Anyone else that starts to compete will start to obtain some reward. 