### PR TITLE
Staging

### DIFF
--- a/folding/__init__.py
+++ b/folding/__init__.py
@@ -1,7 +1,7 @@
 from .protocol import FoldingSynapse
 from .validators.protein import Protein
 
-__version__ = "0.0.2"
+__version__ = "0.1.0"
 version_split = __version__.split(".")
 __spec_version__ = (
     (10000 * int(version_split[0]))

--- a/folding/base/neuron.py
+++ b/folding/base/neuron.py
@@ -174,7 +174,7 @@ class BaseNeuron(ABC):
         """
         return (
             self.block - self.metagraph.last_update[self.uid]
-        ) > self.config.neuron.epoch_length
+        ) > self.config.neuron.metagraph_resync_length
 
     def should_set_weights(self) -> bool:
         # Don't set weights on initialization.

--- a/folding/base/validator.py
+++ b/folding/base/validator.py
@@ -159,6 +159,11 @@ class BaseValidatorNeuron(BaseNeuron):
 
                 # TODO: maybe concurrency for the loop below
                 for job in self.store.get_queue(ready=False).queue:
+                    # Remove any deregistered hotkeys from current job. This will update the store when the job is updated.
+                    if not job.check_for_available_hotkeys(self.metagraph.hotkeys):
+                        self.store.update(job=job)
+                        continue
+
                     # Here we straightforwardly query the workers associated with each job and update the jobs accordingly
                     job_event = self.forward(job=job)
 

--- a/folding/rewards/reward_pipeline.py
+++ b/folding/rewards/reward_pipeline.py
@@ -1,4 +1,5 @@
 import torch
+import bittensor as bt
 from folding.store import Job
 from folding.rewards.linear_reward import divide_decreasing
 
@@ -17,6 +18,14 @@ def reward_pipeline(
         job (Job)
     """
     nonzero_energies = torch.nonzero(energies)
+
+    # Edge case: previously best miner was deregistered but their loss is still the best.
+    if job.best_hotkey not in job.hotkeys:
+        bt.logging.warning(
+            f"Best hotkey {job.best_hotkey} not in hotkeys {job.hotkeys}... {job.best_hotkey} is not registered on the metagraph. Assigning no rewards."
+        )
+        return rewards  # rewards of all 0s.
+
     best_index = job.hotkeys.index(job.best_hotkey)
 
     # There are cases where the top_miner stops replying. ensure to assign reward.

--- a/folding/store.py
+++ b/folding/store.py
@@ -184,12 +184,34 @@ class Job:
             self.best_hotkey = hotkey
             self.commit_hash = commit_hash
             self.gro_hash = gro_hash
-        elif (
+        elif (  # if loss has been improved but not recently enough, trigger early stopping
             pd.Timestamp.now().floor("s") - self.best_loss_at
             > self.max_time_no_improvement
             and self.updated_count >= self.min_updates
         ):
             self.active = False
+        elif (  # if loss has never been improved and the job has been running a long time, trigger early stopping
+            isinstance(
+                self.best_loss_at, pd._libs.tslibs.nattype.NaTType
+            )  # a best loss has not been assigned
+            and pd.Timestamp.now().floor("s") - self.created_at
+            > self.max_time_no_improvement  # the time since the last best loss is greater than the max allowed time
+        ):
+            self.active = False
+
+    def check_for_available_hotkeys(self, hotkeys: List[str]) -> bool:
+        """Checks the job's hotkeys to only include those that are still valid.
+        if no hotkeys are left, the job is set to inactive."""
+
+        # Get the list of hotkeys that are still valid and set the attribute.
+        self.hotkeys = list(set(self.hotkeys) & set(hotkeys))
+
+        # If no hotkeys are left, set the job to inactive and return False
+        if not self.hotkeys:
+            self.active = False
+            return False
+
+        return True
 
 
 class MockJob(Job):

--- a/folding/store.py
+++ b/folding/store.py
@@ -200,8 +200,11 @@ class Job:
             self.active = False
 
     def check_for_available_hotkeys(self, hotkeys: List[str]) -> bool:
-        """Checks the job's hotkeys to only include those that are still valid.
-        if no hotkeys are left, the job is set to inactive."""
+        """Checks the job's hotkeys to only include those that are still valid. This permanently removes hotkeys from a job. If no hotkeys are left, the job is set to inactive.
+        
+        Returns:
+            bool : True if there are remaining hotkeys in the job, and False if there are none.
+        """
 
         # Get the list of hotkeys that are still valid and set the attribute.
         self.hotkeys = list(set(self.hotkeys) & set(hotkeys))

--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -62,13 +62,20 @@ def add_args(cls, parser):
     Adds relevant arguments to the parser for operation.
     """
 
-    parser.add_argument("--netuid", type=int, help="Subnet netuid", default=89)
+    parser.add_argument("--netuid", type=int, help="Subnet netuid", default=25)
 
     parser.add_argument(
         "--neuron.device",
         type=str,
         help="Device to run on.",
         default="cpu",
+    )
+    
+    parser.add_argument(
+        "--neuron.metagraph_resync_length",
+        type=int,
+        help="The number of blocks until metagraph is resynced.",
+        default=100,
     )
 
     parser.add_argument(

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -77,7 +77,6 @@ class Validator(BaseValidatorNeuron):
         Returns:
             List[int]: List of uids
         """
-        # TODO: check if uid is active
         return [
             self.metagraph.hotkeys.index(hotkey)
             for hotkey in hotkeys

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -77,6 +77,7 @@ class Validator(BaseValidatorNeuron):
         Returns:
             List[int]: List of uids
         """
+        # TODO: check if uid is active
         return [
             self.metagraph.hotkeys.index(hotkey)
             for hotkey in hotkeys
@@ -185,18 +186,6 @@ class Validator(BaseValidatorNeuron):
                 bt.logging.warning(
                     f"Received all zero energies for {job.pdb} but stored best_loss < np.inf... Giving rewards."
                 )
-
-            if (
-                pd.Timestamp.now().floor("s") - job.created_at
-                > job.max_time_no_improvement
-            ):
-                if isinstance(job.best_loss_at, pd._libs.tslibs.nattype.NaTType):
-                    # means that nothing has been sampled from any miners and not updated.
-                    # apply_pipeline could be True here, so we still apply rewards one last time.
-                    bt.logging.warning(
-                        f"Job {job.pdb} has not been updated since creation. Removing from queue."
-                    )
-                    job.active = False
         else:
             apply_pipeline = True
             bt.logging.success("Non-zero energies received. Applying reward pipeline.")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -82,6 +82,7 @@ class Validator(BaseValidatorNeuron):
             self.metagraph.hotkeys.index(hotkey)
             for hotkey in hotkeys
             if hotkey in self.metagraph.hotkeys
+            and self.metagraph.axons[self.metagraph.hotkeys.index(hotkey)].is_serving
         ]
 
     def forward(self, job: Job) -> dict:

--- a/tests/test_dropping_hotkeys.py
+++ b/tests/test_dropping_hotkeys.py
@@ -1,0 +1,100 @@
+import os
+import pytest
+import shutil
+import torch
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+from folding.store import PandasJobStore, Job
+from folding.rewards.reward_pipeline import reward_pipeline as pipeline
+
+ROOT_PATH = Path(__file__).parent
+DB_PATH = os.path.join(ROOT_PATH, "mock_data")
+PDB = "ab12"
+FF = "charmm27"
+BOX = "cubic"
+WATER = "tip3p"
+
+
+def delete_db_path():
+    if os.path.exists(DB_PATH):
+        shutil.rmtree(DB_PATH)
+
+
+def insert_single_job_in_store():
+    epsilon = 1e-5
+
+    store = PandasJobStore(db_path=DB_PATH, force_create=True)
+    info = {
+        "pdb": PDB,
+        "ff": FF,
+        "box": BOX,
+        "water": WATER,
+        "hotkeys": ["a", "b", "c", "d"],
+        "created_at": pd.Timestamp.now().floor("s"),
+        "updated_at": pd.Timestamp.now().floor("s"),
+        "epsilon": epsilon,
+    }
+
+    job = Job(**info)
+    store.insert(
+        pdb=job.pdb,
+        ff=job.ff,
+        box=job.box,
+        water=job.water,
+        hotkeys=job.hotkeys,
+        epsilon=epsilon,
+    )
+
+    return store, job
+
+
+def determine_bests(job: Job, energies: torch.Tensor):
+    best_index = energies.argmin()
+    best_loss = energies[best_index].item()
+    best_hotkey = job.hotkeys[best_index]
+
+    return best_index, best_loss, best_hotkey
+
+
+def test_hotkey_drop():
+    delete_db_path()
+
+    top_reward = 0.8
+    store, job = insert_single_job_in_store()
+
+    energies = torch.Tensor([0, 0, 0, -10000])
+    rewards = torch.zeros(len(energies))
+
+    best_index, best_loss, best_hotkey = determine_bests(job=job, energies=energies)
+
+    job.update(
+        loss=best_loss,
+        hotkey=best_hotkey,
+        commit_hash="",
+        gro_hash="",
+    )
+
+    rewards = pipeline(
+        energies=energies, rewards=rewards, top_reward=top_reward, job=job
+    )
+
+    assert job.best_hotkey == "d"
+
+    # Now we need to remove the best hotkey from the store to ensure that the pipeline is working correctly
+    job.hotkeys = ["a", "b", "c"]
+    store.update(job=job)
+
+    job = store.get_queue(ready=False).queue[0]
+
+    energies = torch.Tensor([0, 0, 0])
+    rewards = torch.zeros(len(energies))
+
+    rewards = pipeline(
+        energies=energies, rewards=rewards, top_reward=top_reward, job=job
+    )
+    assert (rewards == 0).all()
+    assert job.best_hotkey == "d"
+    assert len(job.hotkeys) == 3


### PR DESCRIPTION
Includes #150 
- The above PR focuses on the idea that hotkeys could become de-registered, and the main issue here is that rewards would be incorrectly assigned. So to fix this, we check what hotkeys are alive on the network, query only these when asking for simulation results, and within the `reward_pipeline`, we check to see if the previous `best_hotkey` is actually within the list of hotkeys we want to reward. If it's not, then it's likely the case that they were de-registered. If this is the case, we assign 0 reward to everyone. The `Job` will still say the old deregistered hotkey is the best until a miner truly beats it.  