### PR TITLE
Features/miner serve

### DIFF
--- a/folding/base/validator.py
+++ b/folding/base/validator.py
@@ -167,6 +167,12 @@ class BaseValidatorNeuron(BaseNeuron):
                     # Here we straightforwardly query the workers associated with each job and update the jobs accordingly
                     job_event = self.forward(job=job)
 
+                    # If we don't have any miners reply to the query, we will make it inactive. 
+                    if len(job_event["energies"]) == 0: 
+                        job.active = False
+                        self.store.update(job=job)
+                        continue 
+
                     if isinstance(job.event, str):
                         job.event = eval(job.event)  # if str, convert to dict.
 

--- a/folding/miners/folding_miner.py
+++ b/folding/miners/folding_miner.py
@@ -331,6 +331,7 @@ class FoldingMiner(BaseMinerNeuron):
                 )
 
                 event["condition"] = "cpu_limit_reached"
+                synapse.miner_serving = False
 
                 return check_synapse(
                     self=self, synapse=synapse, event=event, output_dir=output_dir

--- a/folding/miners/folding_miner.py
+++ b/folding/miners/folding_miner.py
@@ -327,7 +327,7 @@ class FoldingMiner(BaseMinerNeuron):
 
             elif len(self.simulations) >= self.max_workers:
                 bt.logging.warning(
-                    f"❗ Cannot start new process: CPU limit reached. ({len(self.simulations)}/{self.max_workers}).❗"
+                    f"❗ Cannot start new process: job limit reached. ({len(self.simulations)}/{self.max_workers}).❗"
                 )
 
                 event["condition"] = "cpu_limit_reached"

--- a/folding/protocol.py
+++ b/folding/protocol.py
@@ -39,11 +39,12 @@ class FoldingSynapse(bt.Synapse):
 
     # Optional runtime args for gromacs
     mdrun_args: str = ""
+    
+    # Miner can decide if they are serving the request or not.
+    miner_serving: bool = True
+
     # Optional request output, filled by recieving axon.
     md_output: typing.Optional[dict] = None
-
-    # Miner can decide if they are serving the request or not.
-    miner_serving: typing.Optional[bool] = True
 
     def deserialize(self) -> int:
         """

--- a/folding/protocol.py
+++ b/folding/protocol.py
@@ -43,7 +43,7 @@ class FoldingSynapse(bt.Synapse):
     md_output: typing.Optional[dict] = None
 
     # Miner can decide if they are serving the request or not.
-    miner_serving: bool = True
+    miner_serving: typing.Optional[bool] = True
 
     def deserialize(self) -> int:
         """

--- a/folding/protocol.py
+++ b/folding/protocol.py
@@ -42,6 +42,9 @@ class FoldingSynapse(bt.Synapse):
     # Optional request output, filled by recieving axon.
     md_output: typing.Optional[dict] = None
 
+    # Miner can decide if they are serving the request or not.
+    miner_serving: bool = True
+
     def deserialize(self) -> int:
         """
         Deserialize the output. This method retrieves the response from

--- a/folding/rewards/reward_pipeline.py
+++ b/folding/rewards/reward_pipeline.py
@@ -19,10 +19,10 @@ def reward_pipeline(
     """
     nonzero_energies = torch.nonzero(energies)
 
-    # Edge case: previously best miner was deregistered but their loss is still the best.
+    # If the best hotkey is not in the set of hotkeys in the job, this means that the top miner has stopped replying.
     if job.best_hotkey not in job.hotkeys:
         bt.logging.warning(
-            f"Best hotkey {job.best_hotkey} not in hotkeys {job.hotkeys}... {job.best_hotkey} is not registered on the metagraph. Assigning no rewards."
+            f"Best hotkey {job.best_hotkey} not in hotkeys {job.hotkeys}. Assigning no reward."
         )
         return rewards  # rewards of all 0s.
 

--- a/folding/store.py
+++ b/folding/store.py
@@ -180,6 +180,7 @@ class Job:
         """Updates the status of a job in the database. If the loss improves, the best loss, hotkey and hashes are updated."""
 
         if hotkeys is not None:
+            assert len(hotkeys) > 0, "hotkeys must be a non-empty list"
             self.hotkeys = hotkeys
 
         if hotkey not in self.hotkeys:

--- a/folding/store.py
+++ b/folding/store.py
@@ -169,8 +169,18 @@ class Job:
     def to_frame(self):
         return pd.DataFrame([self.to_series()])
 
-    def update(self, loss: float, hotkey: str, commit_hash: str, gro_hash: str):
+    def update(
+        self,
+        loss: float,
+        hotkey: str,
+        commit_hash: str,
+        gro_hash: str,
+        hotkeys: List[str] = None,
+    ):
         """Updates the status of a job in the database. If the loss improves, the best loss, hotkey and hashes are updated."""
+
+        if hotkeys is not None:
+            self.hotkeys = hotkeys
 
         if hotkey not in self.hotkeys:
             raise ValueError(f"Hotkey {hotkey!r} is not a valid choice")
@@ -201,7 +211,7 @@ class Job:
 
     def check_for_available_hotkeys(self, hotkeys: List[str]) -> bool:
         """Checks the job's hotkeys to only include those that are still valid. This permanently removes hotkeys from a job. If no hotkeys are left, the job is set to inactive.
-        
+
         Returns:
             bool : True if there are remaining hotkeys in the job, and False if there are none.
         """

--- a/folding/utils/ops.py
+++ b/folding/utils/ops.py
@@ -252,6 +252,7 @@ def get_response_info(responses: List[FoldingSynapse]) -> Dict:
     response_status_codes = []
     response_returned_files = []
     response_returned_files_sizes = []
+    response_miners_serving = []
 
     for resp in responses:
         if resp.dendrite.process_time != None:
@@ -263,6 +264,7 @@ def get_response_info(responses: List[FoldingSynapse]) -> Dict:
         response_status_codes.append(str(resp.dendrite.status_code))
         response_returned_files.append(list(resp.md_output.keys()))
         response_returned_files_sizes.append(list(map(len, resp.md_output.values())))
+        response_miners_serving.append(resp.miner_serving)
 
     return {
         "response_times": response_times,
@@ -270,6 +272,7 @@ def get_response_info(responses: List[FoldingSynapse]) -> Dict:
         "response_status_codes": response_status_codes,
         "response_returned_files": response_returned_files,
         "response_returned_files_sizes": response_returned_files_sizes,
+        "response_miners_serving": response_miners_serving,
     }
 
 

--- a/folding/utils/uids.py
+++ b/folding/utils/uids.py
@@ -39,7 +39,8 @@ def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.LongTensor
     candidate_uids = []
     avail_uids = []
 
-    for uid in range(self.metagraph.n.item()):
+    # for uid in range(self.metagraph.n.item()):
+    for uid in [26, 51]:
         uid_is_available = check_uid_availability(
             self.metagraph, uid, self.config.neuron.vpermit_tao_limit
         )

--- a/folding/utils/uids.py
+++ b/folding/utils/uids.py
@@ -39,8 +39,7 @@ def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.LongTensor
     candidate_uids = []
     avail_uids = []
 
-    # for uid in range(self.metagraph.n.item()):
-    for uid in [26, 51]:
+    for uid in range(self.metagraph.n.item()):
         uid_is_available = check_uid_availability(
             self.metagraph, uid, self.config.neuron.vpermit_tao_limit
         )

--- a/folding/validators/forward.py
+++ b/folding/validators/forward.py
@@ -46,14 +46,16 @@ def run_step(
 
     # There are hotkeys that have decided to stop serving. We need to remove them from the store.
     responses_serving = []
+    active_uids = []
     for ii, state in enumerate(response_info["response_miners_serving"]):
         if state:
             responses_serving.append(responses[ii])
+            active_uids.append(uids[ii])
     
     event = {
         "block": self.block,
         "step_length": time.time() - start_time,
-        "uids": uids,
+        "uids": active_uids,
         "energies": [],
         **response_info,
     }
@@ -63,7 +65,7 @@ def run_step(
         return event
 
     energies, energy_event = get_energies(
-        protein=protein, responses=responses_serving, uids=uids
+        protein=protein, responses=responses_serving, uids=active_uids
     )
 
     # Log the step event.

--- a/folding/validators/forward.py
+++ b/folding/validators/forward.py
@@ -1,6 +1,4 @@
-import os
 import time
-import torch
 from tqdm import tqdm
 import bittensor as bt
 from pathlib import Path
@@ -14,9 +12,6 @@ from folding.protocol import FoldingSynapse
 from folding.utils.ops import select_random_pdb_id, load_pdb_ids, get_response_info
 from folding.validators.hyperparameters import HyperParameters
 
-
-from bittensor import dendrite
-
 ROOT_DIR = Path(__file__).resolve().parents[2]
 PDB_IDS = load_pdb_ids(
     root_dir=ROOT_DIR, filename="pdb_ids.pkl"
@@ -29,7 +24,7 @@ def run_step(
     uids: List[int],
     timeout: float,
     mdrun_args="",  #'-ntomp 64' #limit the number of threads to 64
-):
+) -> Dict:
     start_time = time.time()
 
     # Get the list of uids to query for this step.
@@ -55,7 +50,7 @@ def run_step(
     )
     response_info = get_response_info(responses=responses)
 
-    # # Log the step event.
+    # Log the step event.
     event = {
         "block": self.block,
         "step_length": time.time() - start_time,

--- a/folding/validators/forward.py
+++ b/folding/validators/forward.py
@@ -42,13 +42,20 @@ def run_step(
         deserialize=True,  # decodes the bytestream response inside of md_outputs.
     )
 
+    response_info = get_response_info(responses=responses)
+
+    # There are hotkeys that have decided to stop serving. We need to remove them from the store.
+    responses_serving = []
+    for ii, state in enumerate(response_info["response_miners_serving"]):
+        if state:
+            responses_serving.append(responses[ii])
+
     # For now we just want to get the losses, we are not rewarding yet
     # TODO: reframe the rewarding classes to just return the loss (e.g energy) for each response
     # We need to be super careful that the shape of losses is the same as the shape of the uids (becuase re refer to things downstream by index and assign rewards to the hotkey at that index)
     energies, energy_event = get_energies(
-        protein=protein, responses=responses, uids=uids
+        protein=protein, responses=responses_serving, uids=uids
     )
-    response_info = get_response_info(responses=responses)
 
     # Log the step event.
     event = {

--- a/folding/validators/forward.py
+++ b/folding/validators/forward.py
@@ -49,23 +49,30 @@ def run_step(
     for ii, state in enumerate(response_info["response_miners_serving"]):
         if state:
             responses_serving.append(responses[ii])
+    
+    event = {
+        "block": self.block,
+        "step_length": time.time() - start_time,
+        "uids": uids,
+        "energies": [],
+        **response_info,
+    }
 
-    # For now we just want to get the losses, we are not rewarding yet
-    # TODO: reframe the rewarding classes to just return the loss (e.g energy) for each response
-    # We need to be super careful that the shape of losses is the same as the shape of the uids (becuase re refer to things downstream by index and assign rewards to the hotkey at that index)
+    if len(responses_serving) == 0:
+        bt.logging.warning(f"❗ No miners serving pdb_id {synapse.pdb_id}... Making job inactive. ❗")
+        return event
+
     energies, energy_event = get_energies(
         protein=protein, responses=responses_serving, uids=uids
     )
 
     # Log the step event.
-    event = {
-        "block": self.block,
-        "step_length": time.time() - start_time,
-        "uids": uids,
-        "energies": energies.tolist(),
-        **response_info,
-        **energy_event,
-    }
+    event.update(
+        {
+            "energies": energies.tolist(),
+            **energy_event
+        }
+    )
 
     if len(protein.md_inputs) > 0:
         event["md_inputs"] = list(protein.md_inputs.keys())

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -173,7 +173,7 @@ class Validator(BaseValidatorNeuron):
         top_reward = 0.80
         apply_pipeline = False
 
-        # There are hotkeys that have decided to stop serving. We need to remove them from the store.
+        # There could be hotkeys that have decided to stop serving. We need to remove them from the store.
         serving_hotkeys = []
         for ii, state in enumerate(job.event["response_miners_serving"]):
             if state:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -173,6 +173,12 @@ class Validator(BaseValidatorNeuron):
         top_reward = 0.80
         apply_pipeline = False
 
+        # There are hotkeys that have decided to stop serving. We need to remove them from the store.
+        serving_hotkeys = []
+        for ii, state in enumerate(job.event["response_miners_serving"]):
+            if state:
+                serving_hotkeys.append(job.hotkeys[ii])
+
         energies = torch.Tensor(job.event["energies"])
         rewards = torch.zeros(len(energies))  # one-hot per update step
 
@@ -180,10 +186,22 @@ class Validator(BaseValidatorNeuron):
         commit_hash = ""  # For next time
         gro_hash = ""  # For next time
 
+        best_index = np.argmin(energies)
+        best_loss = energies[best_index].item()  # item because it's a torch.tensor
+        best_hotkey = serving_hotkeys[best_index]
+
+        job.update(
+            hotkeys=serving_hotkeys,
+            loss=best_loss,
+            hotkey=best_hotkey,
+            commit_hash=commit_hash,
+            gro_hash=gro_hash,
+        )
+
         # If no miners respond appropriately, the energies will be all zeros
         if (energies == 0).all():
             # All miners not responding but there is at least ONE miner that did in the past. Give them rewards.
-            if job.best_loss < np.inf:
+            if job.best_loss < 0:
                 apply_pipeline = True
                 bt.logging.warning(
                     f"Received all zero energies for {job.pdb} but stored best_loss < np.inf... Giving rewards."
@@ -193,23 +211,12 @@ class Validator(BaseValidatorNeuron):
             bt.logging.success("Non-zero energies received. Applying reward pipeline.")
 
         if apply_pipeline:
-            best_index = np.argmin(energies)
-            best_loss = energies[best_index].item()  # item because it's a torch.tensor
-            best_hotkey = job.hotkeys[best_index]
-
-            # This does a bunch of important things:
-            # 1. checks if best loss in this round is the best loss overall and updates the best_hotkey and hashes accordingly
-            # 2. Potentially applies early stopping criteria
-            # 3. Ensures that all timestamps and counters are updated correctly
-            job.update(
-                loss=best_loss,
-                hotkey=best_hotkey,
-                commit_hash=commit_hash,
-                gro_hash=gro_hash,
-            )
-
             rewards: torch.Tensor = reward_pipeline(
-                energies=energies, rewards=rewards, top_reward=top_reward, job=job
+                energies=energies,
+                rewards=rewards,
+                top_reward=top_reward,
+                job=job,
+                metagraph=self.metagraph,
             )
 
             uids = self.get_uids(hotkeys=job.hotkeys)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -204,7 +204,7 @@ class Validator(BaseValidatorNeuron):
             if job.best_loss < 0:
                 apply_pipeline = True
                 bt.logging.warning(
-                    f"Received all zero energies for {job.pdb} but stored best_loss < np.inf... Giving rewards."
+                    f"Received all zero energies for {job.pdb} but stored best_loss < 0... Applying reward pipeline."
                 )
         else:
             apply_pipeline = True

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -4,14 +4,11 @@
 source .venv/bin/activate
 
 # Execute the Python script
-python ./neurons/validator.py \
-    --netuid 141 \
-    --subtensor.network test \
-    --wallet.name testnet \
-    --wallet.hotkey v1 \
-    --neuron.queue_size 1 \
-    --neuron.sample_size 2 \
-    --neuron.update_interval 20 \
-    --protein.max_steps 50000 \
-    --wandb.off \
-    # --mdrun_args.maxh 0.006 #about 20s
+python3 ./neurons/validator.py \
+    --netuid 25 \
+    --subtensor.network finney \
+    --wallet.name <test_coldkey> \
+    --wallet.hotkey <test_hotkey> \
+    --axon.port <your_port> \
+    --neuron.queue_size <number of pdb_ids to submit> \
+    --neuron.sample_size <number of miners per pdb_id> \

--- a/scripts/run_validator.sh
+++ b/scripts/run_validator.sh
@@ -4,11 +4,14 @@
 source .venv/bin/activate
 
 # Execute the Python script
-python3 ./neurons/validator.py \
-    --netuid 25 \
-    --subtensor.network finney \
-    --wallet.name <test_coldkey> \
-    --wallet.hotkey <test_hotkey> \
-    --axon.port <your_port> \
-    --neuron.queue_size <number of pdb_ids to submit> \
-    --neuron.sample_size <number of miners per pdb_id> \
+python ./neurons/validator.py \
+    --netuid 141 \
+    --subtensor.network test \
+    --wallet.name testnet \
+    --wallet.hotkey v1 \
+    --neuron.queue_size 1 \
+    --neuron.sample_size 2 \
+    --neuron.update_interval 20 \
+    --protein.max_steps 50000 \
+    --wandb.off \
+    # --mdrun_args.maxh 0.006 #about 20s


### PR DESCRIPTION
This PR includes logic for the following: 
1. Fixes the edge case where all miners reply with 0s and the job is never closed. We now _always_ update the job, regardless of the returned states 
2. New functionality for miners to reject being in the job pool for a pdb, as to not lower their scores artifically when they are not replying at all. 