### PR TITLE
Features/unique jobs

### DIFF
--- a/folding/miners/folding_miner.py
+++ b/folding/miners/folding_miner.py
@@ -176,12 +176,12 @@ class FoldingMiner(BaseMinerNeuron):
                     bt.logging.warning(
                         f"✅ {pdb_id} finished simulation... Removing from execution stack ✅"
                     )
-                    sims_to_delete.append(pdb_id)
+                    sims_to_delete.append(pdb_hash)
 
             for pdb_hash in sims_to_delete:
                 del self.simulations[pdb_hash]
 
-            running_simulations = [sim["pdb_id"] for sim in self.simulations]
+            running_simulations = [sim["pdb_id"] for sim in self.simulations.values()]
 
             event["running_simulations"] = running_simulations
             bt.logging.warning(f"Simulations Running: {running_simulations}")
@@ -258,6 +258,7 @@ class FoldingMiner(BaseMinerNeuron):
                 return self.submit_simulation(
                     synapse=synapse,
                     pdb_id=pdb_id,
+                    pdb_hash=pdb_hash,
                     output_dir=output_dir,
                     system_config_filepath=system_config_filepath,
                     event=event,
@@ -345,6 +346,7 @@ class FoldingMiner(BaseMinerNeuron):
         synapse: JobSubmissionSynapse,
         output_dir: str,
         pdb_id: str,
+        pdb_hash: str,
         system_config_filepath: str,
         event: Dict,
     ):
@@ -352,7 +354,6 @@ class FoldingMiner(BaseMinerNeuron):
         check_if_directory_exists(output_directory=output_dir)
 
         # We are going to use a hash based on the pdb_id and the system config to index the simulation dict
-        pdb_hash = self.get_simulation_hash(pdb_id=pdb_id, system_config=synapse.system_config)
 
         # The following files are required for openmm simulations and are received from the validator
         for filename, content in synapse.md_inputs.items():

--- a/folding/miners/folding_miner.py
+++ b/folding/miners/folding_miner.py
@@ -7,6 +7,7 @@ import hashlib
 import concurrent.futures
 from collections import defaultdict
 from typing import Dict, List, Tuple
+import copy
 
 import bittensor as bt
 import openmm.app as app
@@ -187,7 +188,7 @@ class FoldingMiner(BaseMinerNeuron):
 
         return event
 
-    def get_simulation_hash(pdb_id: str, system_config: Dict) -> str:
+    def get_simulation_hash(self, pdb_id: str, system_config: Dict) -> str:
         """Creates a simulation hash based on the pdb_id and the system_config given.
 
         Returns:
@@ -256,6 +257,7 @@ class FoldingMiner(BaseMinerNeuron):
             if len(self.simulations) < self.max_workers:
                 return self.submit_simulation(
                     synapse=synapse,
+                    pdb_id=pdb_id,
                     output_dir=output_dir,
                     system_config_filepath=system_config_filepath,
                     event=event,
@@ -350,7 +352,7 @@ class FoldingMiner(BaseMinerNeuron):
         check_if_directory_exists(output_directory=output_dir)
 
         # We are going to use a hash based on the pdb_id and the system config to index the simulation dict
-        pdb_hash = self.get_simulation_hash(pdb_id=pdb_id, system_config=system_config)
+        pdb_hash = self.get_simulation_hash(pdb_id=pdb_id, system_config=synapse.system_config)
 
         # The following files are required for openmm simulations and are received from the validator
         for filename, content in synapse.md_inputs.items():

--- a/folding/miners/folding_miner.py
+++ b/folding/miners/folding_miner.py
@@ -1,19 +1,15 @@
-import base64
-import concurrent.futures
-import glob
 import os
-import random
 import time
+import glob
+import base64
+import random
+import hashlib
+import concurrent.futures
 from collections import defaultdict
 from typing import Dict, List, Tuple
-from sys import stdout
-import copy
-
 
 import bittensor as bt
-import openmm as mm
 import openmm.app as app
-import openmm.unit as unit
 
 # import base miner class which takes care of most of the boilerplate
 from folding.base.miner import BaseMinerNeuron
@@ -25,7 +21,6 @@ from folding.utils.ops import (
     check_if_directory_exists,
     get_tracebacks,
     write_pkl,
-    load_pkl,
 )
 from folding.utils.opemm_simulation_config import SimulationConfig
 
@@ -192,17 +187,18 @@ class FoldingMiner(BaseMinerNeuron):
 
         return event
 
-    def get_simulation_hash(pdb_id: str, system_config: Dict) -> int:
+    def get_simulation_hash(pdb_id: str, system_config: Dict) -> str:
         """Creates a simulation hash based on the pdb_id and the system_config given.
 
         Returns:
-            int: A value that describes the system
+            str: first 6 characters of a sha256 hash
         """
         system_hash = pdb_id
         for key, value in system_config.items():
             system_hash += str(key) + str(value)
 
-        return hash(system_hash)
+        hash_object = hashlib.sha256(system_hash.encode("utf-8"))
+        return hash_object.hexdigest()[:6]
 
     def is_unique_job(self, system_config_filepath: str) -> bool:
         """Check to see if a submitted job is unique by checking to see if the folder exists.

--- a/folding/miners/folding_miner.py
+++ b/folding/miners/folding_miner.py
@@ -169,7 +169,7 @@ class FoldingMiner(BaseMinerNeuron):
 
             for pdb_hash, simulation in self.simulations.items():
                 current_executor_state = simulation["executor"].get_state()
-                pdb_id = simulation[pdb_id]
+                pdb_id = simulation["pdb_id"]
 
                 if current_executor_state == "finished":
                     bt.logging.warning(

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -64,7 +64,7 @@ class Protein(OpenMMSimulation):
         self.water: str = water
 
         self.system_config = SimulationConfig(
-            ff=self.ff, water=self.water, box=self.box, seed=self.gen_seed()
+            ff=self.ff, water=self.water, box=self.box, seed=25
         )
 
         self.config = config


### PR DESCRIPTION
This PR supports the new desired functionality for _unique_ job submissions. Currently, miners who have seen the same pdb before will submit that simulation information without acknowledging what the configuration would be. Now, we parameterize the systems using a `pdh_hash` which is a value derived from the `system_config` and the `pdb_id`