### PR TITLE
add wandb (in)active flag to runs for snowflake datapipeline

### DIFF
--- a/folding/base/neuron.py
+++ b/folding/base/neuron.py
@@ -122,17 +122,19 @@ class BaseNeuron(ABC):
             raise e
 
         bt.logging.success(f"Running OpenMM version: {self.openmm_version}")
-        
+
     def setup_wandb_logging(self):
         if os.path.isfile(f"{self.config.neuron.full_path}/wandb_ids.pkl"):
-            self.wandb_ids = load_pkl(f"{self.config.neuron.full_path}/wandb_ids.pkl", "rb")
+            self.wandb_ids = load_pkl(
+                f"{self.config.neuron.full_path}/wandb_ids.pkl", "rb"
+            )
         else:
             self.wandb_ids = {}
-            
+
     def add_wandb_id(self, pdb_id: str, wandb_id: str):
-        self.wandb_ids[pdb_id] = wandb_id
+        self.wandb_ids[pdb_id] = {"wandb_id": wandb_id, "status": "active"}
         write_pkl(self.wandb_ids, f"{self.config.neuron.full_path}/wandb_ids.pkl", "wb")
-        
+
     def remove_wandb_id(self, pdb_id: str):
         self.wandb_ids.pop(pdb_id)
         write_pkl(self.wandb_ids, f"{self.config.neuron.full_path}/wandb_ids.pkl", "wb")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -312,16 +312,21 @@ class Validator(BaseValidatorNeuron):
         bt.logging.success(f"Event information: {merged_events}")
         event = prepare_event_for_logging(merged_events)
 
-        # If the job is finished, remove the pdb directory
         pdb_location = None
         protein = Protein.from_job(job=job, config=self.config.protein)
+
+        if event["updated_count"] == 1:
+            # We want to visualize the protein only once.
+            pdb_location = protein.pdb_location
+
+        if job.active is False:
+            self.wandb_ids[job.pdb]["status"] = "inactive"
+
+        log_event(self, event=event, pdb_location=pdb_location)
+
         if job.active is False:
             self.remove_wandb_id(job.pdb)
             protein.remove_pdb_directory()
-        elif event["updated_count"] == 1:
-            pdb_location = protein.pdb_location
-
-        log_event(self, event=event, pdb_location=pdb_location)
 
 
 # The main function parses the configuration and runs the validator.


### PR DESCRIPTION
This attempts to add a wandb tag to the run so that @cassova can pull data without issue from the new logging schema. Validators that break and need to restart will reload the state of all previous wandb logs, so this is not a failure mode 