### PR TITLE
fix eval nan bug

### DIFF
--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -21,6 +21,7 @@ from pdbfixer import PDBFixer
 from folding.store import Job
 from folding.utils.opemm_simulation_config import SimulationConfig
 from folding.utils.ops import (
+    OpenMMException,
     check_and_download_pdbs,
     check_if_directory_exists,
     load_pdb_ids,
@@ -221,12 +222,13 @@ class Protein(OpenMMSimulation):
 
         self.pdb_complexity = Protein._get_pdb_complexity(self.pdb_location)
         self.init_energy = self.calc_init_energy()
+
         # Checking if init energy is nan
         if self.init_energy != self.init_energy:
-            bt.logging.error(
-                f"Failed to calculate initial energy for {self.pdb_id}... Exiting!"
+            raise OpenMMException(
+                f"Failed to calculate initial energy for {self.pdb_id}"
             )
-            raise ValueError(f"Failed to calculate initial energy for {self.pdb_id}")
+
         self._calculate_epsilon()
 
     def __str__(self):

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -221,6 +221,12 @@ class Protein(OpenMMSimulation):
 
         self.pdb_complexity = Protein._get_pdb_complexity(self.pdb_location)
         self.init_energy = self.calc_init_energy()
+        # Checking if init energy is nan
+        if self.init_energy != self.init_energy:
+            bt.logging.error(
+                f"Failed to calculate initial energy for {self.pdb_id}... Exiting!"
+            )
+            raise ValueError(f"Failed to calculate initial energy for {self.pdb_id}")
         self._calculate_epsilon()
 
     def __str__(self):
@@ -411,9 +417,9 @@ class Protein(OpenMMSimulation):
 
             # Make sure that we are enough steps ahead in the log file compared to the checkpoint file.
             # Checks if log_file is 5000 steps ahead of checkpoint AND that the log_file has at least 5000 steps
-            if (
-                self.log_step - self.simulation.currentStep
-            ) < 5000 and len(self.log_file) >= 5000:
+            if (self.log_step - self.simulation.currentStep) < 5000 and len(
+                self.log_file
+            ) >= 5000:
                 checkpoint_path = os.path.join(
                     self.miner_data_directory, f"{self.current_state}_old.cpt"
                 )


### PR DESCRIPTION
In relation to reports such as [this](https://discord.com/channels/799672011265015819/1234881153832321024/1288791456391106645)

When init_energy is nan it then gets saved in the job store and saved into a csv and when we eval it, it won't be recognized Staging