### PR TITLE
Added logic that if from_job fails we stop the job and continue

### DIFF
--- a/folding/store.py
+++ b/folding/store.py
@@ -153,7 +153,7 @@ class Job:
     gro_hash: str = None
     update_interval: pd.Timedelta = pd.Timedelta(minutes=10)
     updated_count: int = 0
-    max_time_no_improvement: pd.Timedelta = pd.Timedelta(minutes=20)
+    max_time_no_improvement: pd.Timedelta = pd.Timedelta(minutes=25)
     min_updates: int = 10
     epsilon: float = 0.05  # percentage.
     event: dict = None

--- a/folding/validators/forward.py
+++ b/folding/validators/forward.py
@@ -49,12 +49,20 @@ def run_ping_step(self, uids: List[int], timeout: float) -> Dict:
 
 def run_step(
     self,
-    protein: Protein,
+    protein: Protein | None,
     uids: List[int],
     timeout: float,
     mdrun_args="",  #'-ntomp 64' #limit the number of threads to 64
 ) -> Dict:
     start_time = time.time()
+    if protein is None:
+        event = {
+            "block": self.block,
+            "step_length": time.time() - start_time,
+            "energies": [],
+            "active": False,
+        }
+        return event
 
     # Get the list of uids to query for this step.
     axons = [self.metagraph.axons[uid] for uid in uids]

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -27,7 +27,6 @@ from folding.utils.ops import (
     select_random_pdb_id,
     write_pkl,
 )
-from folding.store import Job
 from folding.base.simulation import OpenMMSimulation
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
@@ -118,8 +117,8 @@ class Protein(OpenMMSimulation):
             bt.logging.error(
                 f"from_job failed for {protein.pdb_id} with Exception {E}."
             )
-        finally:
-            return protein
+            return None
+        return protein
 
     @staticmethod
     def load_pdb_as_string(pdb_path: str) -> str:
@@ -411,9 +410,9 @@ class Protein(OpenMMSimulation):
 
             # Make sure that we are enough steps ahead in the log file compared to the checkpoint file.
             # Checks if log_file is 5000 steps ahead of checkpoint AND that the log_file has at least 5000 steps
-            if (
-                self.log_step - self.simulation.currentStep
-            ) < 5000 and len(self.log_file) >= 5000:
+            if (self.log_step - self.simulation.currentStep) < 5000 and len(
+                self.log_file
+            ) >= 5000:
                 checkpoint_path = os.path.join(
                     self.miner_data_directory, f"{self.current_state}_old.cpt"
                 )

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -316,10 +316,14 @@ class Validator(BaseValidatorNeuron):
         # If the job is finished, remove the pdb directory
         pdb_location = None
         protein = Protein.from_job(job=job, config=self.config.protein)
-        if job.active is False:
-            protein.remove_pdb_directory()
-        elif event["updated_count"] == 1:
-            pdb_location = protein.pdb_location
+
+        if protein is not None:
+            if job.active is False:
+                protein.remove_pdb_directory()
+            elif event["updated_count"] == 1:
+                pdb_location = protein.pdb_location
+        else:
+            bt.logging.error(f"Protein.from_job returns NONE for protein {job.pdb}")
 
         log_event(self, event=event, pdb_location=pdb_location)
 


### PR DESCRIPTION
This is to catch edge cases such as the MUV error, this will make it so that validators will not restart on such errors