### PR TITLE
started saving logging files to wandb

### DIFF
--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -194,7 +194,7 @@ def add_args(cls, parser):
         "--neuron.events_retention_size",
         type=str,
         help="Events retention size.",
-        default="2 GB",
+        default="25 MB",
     )
 
     parser.add_argument(

--- a/folding/utils/logging.py
+++ b/folding/utils/logging.py
@@ -4,6 +4,7 @@ from typing import List
 from loguru import logger
 from dataclasses import asdict, dataclass
 import datetime as dt
+import os
 
 import folding
 import bittensor as bt
@@ -113,6 +114,7 @@ def log_event(self, event, failed=False, pdb_location: str = None):
 
     # Log the event to wandb.
     run.log(event)
+    wandb.save(os.path.join(self.config.neuron.full_path, f"events.log"))
 
     if pdb_location is not None:
         log_protein(run, pdb_id_path=pdb_location)


### PR DESCRIPTION
Since we changed the way we log on wandb, we don't save cohesive log files into wandb. This PR saves terminal logs into the wandb run as a file