### PR TITLE
Exploit fixes

### DIFF
--- a/folding/validators/reward.py
+++ b/folding/validators/reward.py
@@ -63,7 +63,7 @@ def get_energies(
             is_valid, checked_energy, miner_energy = protein.is_run_valid()
             event["is_run_valid"][i] = time.time() - start_time
 
-            energies[i] = energy if is_valid else 0
+            energies[i] = checked_energy[-1] if is_valid else 0
 
             event["checked_energy"][i] = checked_energy
             event["miner_energy"][i] = miner_energy


### PR DESCRIPTION
1. Exploit where miners could get through gradient detection by modifying miner logs, we're now basing gradient detection on `check_energy` which is generated by the validator. Example: https://wandb.ai/macrocosmos/folding-openmm/runs/pyb46ll1/overview. Miner number 9 has a miner log that looks like this: 
![image](https://github.com/user-attachments/assets/8b1e1517-e442-439b-b458-b2184b2c80d9)


2. There is an exploit where miners get lower energies in their checkpoints without causing a gradient in check_energy. An example: https://wandb.ai/macrocosmos/folding-openmm/runs/g3019uur/overview some energies are way lower than any energy observed in `miner_energy` or `checked_energy`

Thank you to our valued community members for elucidating these issues to us! Thank you Kumiho, Loayei, BC | Tensorized, OzLancer