### PR TITLE
OpenMMException to the validator forward.

### DIFF
--- a/folding/validators/forward.py
+++ b/folding/validators/forward.py
@@ -17,6 +17,7 @@ from folding.validators.hyperparameters import HyperParameters
 from folding.utils.ops import (
     load_and_sample_random_pdb_ids,
     get_response_info,
+    OpenMMException,
 )
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
@@ -260,6 +261,10 @@ def try_prepare_challenge(config, pdb_id: str) -> Dict:
                 raise ValueError(
                     f"Initial energy is positive: {protein.init_energy}. Simulation failed."
                 )
+
+        except OpenMMException as e:
+            bt.logging.error(f"OpenMMException occurred: init_energy is NaN {e}")
+            event["validator_search_status"] = False
 
         except Exception:
             # full traceback


### PR DESCRIPTION
Currently we raise a value error if the init_energy is positive. We also need to account for the scenario where  protein.setup_simulation() returns a NaN init energy and an OpenMMExceptions is raised. This PR ensures that the OpenMMException is caught, so proteins with Nan init energies dont make their way to the miners. 