### PR TITLE
Staging

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: folding  # Replace with your environment name
+name: szymon-folding  # Replace with your environment name
 channels:
   - defaults
   - conda-forge  # Add other channels if needed
@@ -20,3 +20,4 @@ dependencies:
       - parmed==4.2.2
       - plotly==5.22.0
       - kaleido==0.2.1
+      - async-timeout==4.0.3

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: szymon-folding  # Replace with your environment name
+name: folding  # Replace with your environment name
 channels:
   - defaults
   - conda-forge  # Add other channels if needed

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - gzip==1.13
   - pip:
       - bittensor==6.9.4
+      - tenacity==9.0.0
       - python-dotenv==1.0.1
       - wandb==0.17.2
       - eth-utils==2.1.1

--- a/folding/__init__.py
+++ b/folding/__init__.py
@@ -1,7 +1,7 @@
 from .protocol import JobSubmissionSynapse
 from .validators.protein import Protein
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 version_split = __version__.split(".")
 __spec_version__ = (
     (10000 * int(version_split[0]))

--- a/folding/base/validator.py
+++ b/folding/base/validator.py
@@ -67,9 +67,6 @@ class BaseValidatorNeuron(BaseNeuron):
             self.metagraph.n, dtype=torch.float32, device=self.device
         )
 
-        # Init sync with the network. Updates the metagraph.
-        self.sync()
-
         # Serve axon to enable external connections.
         if not self.config.neuron.axon_off:
             self.serve_axon()

--- a/folding/base/validator.py
+++ b/folding/base/validator.py
@@ -19,7 +19,6 @@
 import os
 import json
 import copy
-import time
 import torch
 import asyncio
 import argparse
@@ -27,13 +26,14 @@ import threading
 import bittensor as bt
 
 from typing import List
-from traceback import print_exception
+from pathlib import Path
 
 from folding.base.neuron import BaseNeuron
 from folding.mock import MockDendrite
 from folding.utils.config import add_validator_args
+from folding.utils.ops import print_on_retry
 
-from pathlib import Path
+from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_result
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 
@@ -107,6 +107,14 @@ class BaseValidatorNeuron(BaseNeuron):
             bt.logging.error(f"Failed to create Axon initialize with exception: {e}")
             pass
 
+    @retry(
+        stop=stop_after_attempt(3),  # Retry up to 3 times
+        wait=wait_fixed(1),  # Wait 1 second between retries
+        retry=retry_if_result(
+            lambda result: result is False
+        ),  # Retry if the result is False
+        after=print_on_retry
+    )
     def set_weights(self):
         """
         Sets the validator weights to the metagraph hotkeys based on the scores it has received from the miners. The weights determine the trust and incentive level the validator assigns to miner nodes on the network.
@@ -158,10 +166,9 @@ class BaseValidatorNeuron(BaseNeuron):
             wait_for_inclusion=False,
             version_key=self.spec_version,
         )
-        if result is True:
-            bt.logging.info("set_weights on chain successfully!")
-        else:
-            bt.logging.error("set_weights failed")
+
+            
+        return result
 
     def resync_metagraph(self):
         """Resyncs the metagraph and updates the hotkeys and moving averages based on the new metagraph."""

--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -208,7 +208,7 @@ def add_args(cls, parser):
         "--protein.input_source",
         type=str,
         help="Specifies the input source for selecting a new protein for simulation.",
-        default=None,
+        default="rcsb",
         choices=["rcsb", "pdbe"],
     )
 

--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -82,7 +82,7 @@ def add_args(cls, parser):
         "--neuron.epoch_length",
         type=int,
         help="The default epoch length (how often we set weights, measured in 12 second blocks).",
-        default=100,
+        default=250,
     )
 
     parser.add_argument(

--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -82,7 +82,7 @@ def add_args(cls, parser):
         "--neuron.epoch_length",
         type=int,
         help="The default epoch length (how often we set weights, measured in 12 second blocks).",
-        default=250,
+        default=100,
     )
 
     parser.add_argument(

--- a/folding/utils/logging.py
+++ b/folding/utils/logging.py
@@ -51,7 +51,6 @@ def init_wandb(self, pdb_id: str, reinit=True, failed=False):
         tags.append("mock")
     if self.config.neuron.disable_set_weights:
         tags.append("disable_set_weights")
-    tags.append("async")
     wandb_config = {
         key: copy.deepcopy(self.config.get(key, None))
         for key in ("neuron", "reward", "netuid", "wandb")

--- a/folding/utils/ops.py
+++ b/folding/utils/ops.py
@@ -71,6 +71,12 @@ def timeout(seconds):
 
     return decorator
 
+def print_on_retry(retry_state):
+    function_name = retry_state.fn.__name__
+    max_retries = retry_state.retry_object.stop.max_attempt_number
+    bt.logging.warning(f"Retrying {function_name}: retry #{retry_state.attempt_number} out of {max_retries}")
+    
+
 
 def delete_directory(directory: str):
     """We create a lot of files in the process of tracking pdb files.

--- a/folding/validators/forward.py
+++ b/folding/validators/forward.py
@@ -183,7 +183,7 @@ async def create_new_challenge(self, exclude: List) -> Dict:
             event["hp_search_time"] = time.time() - forward_start_time
 
             # only log the event if the simulation was not successful
-            await log_event(self, event, failed=True)
+            log_event(self, event, failed=True)
             bt.logging.debug(
                 f"❌❌ All hyperparameter combinations failed for pdb_id {pdb_id}.. Skipping! ❌❌"
             )

--- a/folding/validators/forward.py
+++ b/folding/validators/forward.py
@@ -173,7 +173,7 @@ async def create_new_challenge(self, exclude: List) -> Dict:
 
         # Perform a hyperparameter search until we find a valid configuration for the pdb
         bt.logging.info(f"Attempting to prepare challenge for pdb {pdb_id}")
-        event = await try_prepare_challenge(config=self.config, pdb_id=pdb_id)
+        event = await try_prepare_challenge(self, config=self.config, pdb_id=pdb_id)
         event["input_source"] = self.config.protein.input_source
 
         if event.get("validator_search_status"):

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -587,7 +587,7 @@ class Protein(OpenMMSimulation):
     def get_ns_computed(self):
         """Calculate the number of nanoseconds computed by the miner."""
 
-        return (self.cpt_step * self.system_config.time_step_size) / 1e6
+        return (self.cpt_step * self.system_config.time_step_size) / 1e3
 
     def save_pdb(self, output_path: str):
         """Save the pdb file to the output path."""

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -371,15 +371,15 @@ class Validator(BaseValidatorNeuron):
                 )
             except Exception as e:
                 bt.logging.error(f"Error in create_jobs: {e}")
+
             await asyncio.sleep(self.config.neuron.update_interval)
 
     async def update_jobs(self):
         while True:
             try:
+                bt.logging.info("Updating jobs.")
                 bt.logging.info(f"step({self.step}) block({self.block})")
 
-                await asyncio.sleep(self.config.neuron.update_interval)
-                bt.logging.info("Updating jobs.")
                 for job in self.store.get_queue(ready=False).queue:
                     # Remove any deregistered hotkeys from current job. This will update the store when the job is updated.
                     if not job.check_for_available_hotkeys(self.metagraph.hotkeys):
@@ -404,10 +404,13 @@ class Validator(BaseValidatorNeuron):
                     await self.update_job(job=job)
             except Exception as e:
                 bt.logging.error(f"Error in update_jobs: {e}")
+
             self.step += 1
+
             bt.logging.info(
                 f"Sleeping {self.config.neuron.update_interval} seconds before next job update loop."
             )
+            await asyncio.sleep(self.config.neuron.update_interval)
 
     async def __aenter__(self):
         self.loop.create_task(self.sync_loop())

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -50,6 +50,9 @@ class Validator(BaseValidatorNeuron):
 
         self.load_state()
 
+        # Init sync with the network. Updates the metagraph.
+        self.sync()
+
         # TODO: Change the store to SQLiteJobStore if you want to use SQLite
         self.store = SQLiteJobStore()
         self.mdrun_args = self.parse_mdrun_args()
@@ -370,8 +373,10 @@ class Validator(BaseValidatorNeuron):
                         f"Sleeping 60 seconds before next job creation loop."
                     )
                 else:
-                    bt.logging.info("Job queue is full. Sleeping 60 seconds before next job creation loop.")
-                
+                    bt.logging.info(
+                        "Job queue is full. Sleeping 60 seconds before next job creation loop."
+                    )
+
             except Exception as e:
                 bt.logging.error(f"Error in create_jobs: {e}")
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -372,7 +372,7 @@ class Validator(BaseValidatorNeuron):
             except Exception as e:
                 bt.logging.error(f"Error in create_jobs: {e}")
 
-            await asyncio.sleep(self.config.neuron.update_interval)
+            await asyncio.sleep(60)
 
     async def update_jobs(self):
         while True:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -366,9 +366,12 @@ class Validator(BaseValidatorNeuron):
                     # Here is where we select, download and preprocess a pdb
                     # We also assign the pdb to a group of workers (miners), based on their workloads
                     await self.add_jobs(k=self.config.neuron.queue_size - queue.qsize())
-                bt.logging.info(
-                    f"Sleeping {self.config.neuron.update_interval} seconds before next job creation loop."
-                )
+                    bt.logging.info(
+                        f"Sleeping 60 seconds before next job creation loop."
+                    )
+                else:
+                    bt.logging.info("Job queue is full. Sleeping 60 seconds before next job creation loop.")
+                
             except Exception as e:
                 bt.logging.error(f"Error in create_jobs: {e}")
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -377,6 +377,9 @@ class Validator(BaseValidatorNeuron):
     async def update_jobs(self):
         while True:
             try:
+                # Wait at the beginning of update_jobs since we want to avoid attemping to update jobs before we get data back.
+                await asyncio.sleep(self.config.neuron.update_interval)
+
                 bt.logging.info("Updating jobs.")
                 bt.logging.info(f"step({self.step}) block({self.block})")
 
@@ -410,7 +413,6 @@ class Validator(BaseValidatorNeuron):
             bt.logging.info(
                 f"Sleeping {self.config.neuron.update_interval} seconds before next job update loop."
             )
-            await asyncio.sleep(self.config.neuron.update_interval)
 
     async def __aenter__(self):
         self.loop.create_task(self.sync_loop())

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -322,7 +322,7 @@ class Validator(BaseValidatorNeuron):
             bt.logging.error(f"Protein.from_job returns NONE for protein {job.pdb}")
 
         # Remove these keys from the log because they polute the terminal.
-        await log_event(
+        log_event(
             self,
             event=event,
             pdb_location=pdb_location,


### PR DESCRIPTION
## Features: 
- Remove async nature of wandb logging because this seems to have unintended issues with wandb getting stuck 
- Add tenacity retry to try and set weights 3 times before moving on. 

## Bug Fixes: 
- Move the initial sync of the validator to the outer loop to avoid deleting previously saved weights 
- Remove the sync inside of the base validator to avoid having miner weights go to 0 on each restart. 

## Extras 
- Increase block time for weight setting from 100 to 250 to help smooth out miner weights