### PR TITLE
return best miner energy for the job so miners can compare

### DIFF
--- a/folding/base/validator.py
+++ b/folding/base/validator.py
@@ -25,6 +25,7 @@ import argparse
 import threading
 import bittensor as bt
 from pathlib import Path
+from loguru import logger
 
 from typing import List, Optional
 
@@ -35,7 +36,6 @@ from folding.organic.validator import OrganicValidator
 from folding.utils.ops import print_on_retry
 
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_result
-from loguru import logger
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 
@@ -99,7 +99,7 @@ class BaseValidatorNeuron(BaseNeuron):
 
             self.loop.create_task(self._organic_scoring.start_loop())
         else:
-            bt.logging.warning(
+            logger.warning(
                 "Organic scoring is not enabled. To enable, remove '--neuron.axon_off' and '--neuron.organic_disabled'"
             )
 
@@ -108,7 +108,7 @@ class BaseValidatorNeuron(BaseNeuron):
     def _serve_axon(self):
         """Serve axon to enable external connections"""
         validator_uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)
-        bt.logging.info(f"Serving validator IP of UID {validator_uid} to chain...")
+        logger.info(f"Serving validator IP of UID {validator_uid} to chain...")
         self.axon.serve(netuid=self.config.netuid, subtensor=self.subtensor).start()
 
     @retry(

--- a/folding/organic/validator.py
+++ b/folding/organic/validator.py
@@ -3,6 +3,7 @@ import copy
 import random
 import asyncio
 import bittensor as bt
+from loguru import logger
 
 from typing import Any, Literal, Union, Tuple
 
@@ -54,7 +55,7 @@ class OrganicValidator(OrganicScoringBase):
 
         config: dict = synapse.get_simulation_params()
         self._organic_queue.add(config)
-        bt.logging.success(
+        logger.success(
             f"Query received: organic queue size = {self._organic_queue.size}"
         )
 
@@ -76,11 +77,11 @@ class OrganicValidator(OrganicScoringBase):
                 logs = await self.forward()
 
                 total_elapsed_time = logs.get("total_elapsed_time", 0)
-                bt.logging.info(
+                logger.info(
                     f"Organic scoring iteration completed in {total_elapsed_time:.2f} seconds."
                 )
 
-                bt.logging.warning(
+                logger.warning(
                     f"Sleeping for {self._validator.config.neuron.organic_trigger_frequency} seconds before next organic check."
                 )
                 await asyncio.sleep(
@@ -88,7 +89,7 @@ class OrganicValidator(OrganicScoringBase):
                 )
 
             except Exception as e:
-                bt.logging.error(
+                logger.error(
                     f"Error occured during organic scoring iteration:\n{e}"
                 )
                 await asyncio.sleep(1)
@@ -138,7 +139,7 @@ class OrganicValidator(OrganicScoringBase):
 
         # If the job was unable to be added to the queue for any reason, add it back to the organic queue.
         if not job_added:
-            bt.logging.warning("adding previously sampled job back to organic queue.")
+            logger.warning("adding previously sampled job back to organic queue.")
             self._organic_queue.add(sample_copy)
             return {
                 "total_elapsed_time": time.perf_counter() - init_time,

--- a/folding/protocol.py
+++ b/folding/protocol.py
@@ -55,7 +55,7 @@ class JobSubmissionSynapse(bt.Synapse):
     # Miner can decide if they are serving the request or not.
     miner_serving: bool = True
 
-    best_submitted_energy: typing.Optional[dict] = None
+    best_submitted_energy: typing.Optional[float] = None
 
     # Optional request output, filled by receiving axon.
     md_output: typing.Optional[dict] = None

--- a/folding/protocol.py
+++ b/folding/protocol.py
@@ -55,6 +55,8 @@ class JobSubmissionSynapse(bt.Synapse):
     # Miner can decide if they are serving the request or not.
     miner_serving: bool = True
 
+    best_submitted_energy: typing.Optional[dict] = None
+
     # Optional request output, filled by receiving axon.
     md_output: typing.Optional[dict] = None
     miner_seed: typing.Optional[int] = None

--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -454,8 +454,7 @@ def add_validator_args(cls, parser):
         help="The validator will only accept organic queries from a list of whitelisted hotkeys.",
         default=[
             "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
-            "5CQ9KNHy9qvRGhLWeV37agEpmLckSgMXzbZWEEXwbupSCTQy",  # personal key
-        ],  # Sets default otf key
+        ],
     )
 
 

--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -18,7 +18,6 @@
 
 import os
 import sys
-import torch
 import argparse
 import bittensor as bt
 from loguru import logger
@@ -453,7 +452,7 @@ def add_validator_args(cls, parser):
         nargs="+",  # Accepts one or more values as a list
         help="The validator will only accept organic queries from a list of whitelisted hotkeys.",
         default=[
-            "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+            "5CQ9KNHy9qvRGhLWeV37agEpmLckSgMXzbZWEEXwbupSCTQy",
         ],
     )
 

--- a/folding/validators/forward.py
+++ b/folding/validators/forward.py
@@ -55,6 +55,7 @@ async def run_step(
     uids: List[int],
     timeout: float,
     mdrun_args="",  # TODO: Remove this
+    best_submitted_energy: float = None,
 ) -> Dict:
     start_time = time.time()
 
@@ -78,6 +79,7 @@ async def run_step(
         md_inputs=protein.md_inputs,
         pdb_contents=protein.pdb_contents,
         system_config=system_config,
+        best_submitted_energy=best_submitted_energy,
     )
 
     # Make calls to the network with the prompt - this is synchronous.

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -19,12 +19,12 @@ import re
 import time
 import random
 import numpy as np
+from loguru import logger
 from itertools import chain
 from typing import Any, Dict, List, Tuple
 
 import torch
 import pandas as pd
-import bittensor as bt
 import asyncio
 
 from async_timeout import timeout
@@ -38,7 +38,6 @@ from folding.validators.protein import Protein
 from folding.store import Job, SQLiteJobStore
 from folding.base.validator import BaseValidatorNeuron
 from folding.utils.logging import log_event
-from loguru import logger
 
 
 class Validator(BaseValidatorNeuron):
@@ -223,11 +222,11 @@ class Validator(BaseValidatorNeuron):
 
                 try:
                     async with timeout(180):
-                        bt.logging.info(
+                        logger.info(
                             f"setup_simulation for organic query: {job_event['pdb_id']}"
                         )
                         await protein.setup_simulation()
-                        bt.logging.success(
+                        logger.success(
                             f"✅✅ {job_event['pdb_id']} simulation ran successfully! ✅✅"
                         )
 
@@ -237,9 +236,9 @@ class Validator(BaseValidatorNeuron):
                         )
 
                 except Exception as e:
-                    bt.logging.error(f"Error in setting up organic query: {e}")
+                    logger.error(f"Error in setting up organic query: {e}")
 
-            bt.logging.info(f"Inserting organic job: {job_event['pdb_id']}")
+            logger.info(f"Inserting organic job: {job_event['pdb_id']}")
             self.store.insert(
                 pdb=job_event["pdb_id"],
                 ff=job_event["ff"],
@@ -253,7 +252,7 @@ class Validator(BaseValidatorNeuron):
 
             return True
         else:
-            bt.logging.warning(
+            logger.warning(
                 f"Not enough available uids to create a job. Requested {self.config.neuron.sample_size}, but number of valid uids is {len(valid_uids)}... Skipping until available"
             )
             return False

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -227,7 +227,7 @@ class Validator(BaseValidatorNeuron):
                         )
                         await protein.setup_simulation()
                         logger.success(
-                            f"✅✅ {job_event['pdb_id']} simulation ran successfully! ✅✅"
+                            f"✅✅ organic {job_event['pdb_id']} simulation ran successfully! ✅✅"
                         )
 
                     if protein.init_energy > 0:
@@ -238,7 +238,7 @@ class Validator(BaseValidatorNeuron):
                 except Exception as e:
                     logger.error(f"Error in setting up organic query: {e}")
 
-            logger.info(f"Inserting organic job: {job_event['pdb_id']}")
+            logger.info(f"Inserting job: {job_event['pdb_id']}")
             self.store.insert(
                 pdb=job_event["pdb_id"],
                 ff=job_event["ff"],

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -126,6 +126,7 @@ class Validator(BaseValidatorNeuron):
             uids=uids,
             timeout=self.config.neuron.timeout,
             mdrun_args=self.mdrun_args,
+            best_submitted_energy=job.best_loss,
         )
 
     async def ping_all_miners(

--- a/tests/test_simulation_executor.py
+++ b/tests/test_simulation_executor.py
@@ -1,15 +1,14 @@
 import pytest
 
 import os
-import time
 import random
 import string
+from loguru import logger
+
 from pathlib import Path
 import concurrent.futures
 from collections import defaultdict
 from folding.miners.folding_miner import MockSimulationManager
-
-import bittensor as bt
 
 ROOT_PATH = Path(__file__).parent
 OUTPUT_PATH = os.path.join(ROOT_PATH, "mock_data", "test_miner")
@@ -83,10 +82,10 @@ def test_simulation_manager(max_workers: int):
                 # This seems to happen because of some IO delay..
                 if os.path.exists(OUTPUT_PATH):
                     if len(os.listdir(OUTPUT_PATH)) == 0:
-                        bt.logging.warning(f"OUTPUT_PATH IS EMPTY... continue")
+                        logger.warning(f"OUTPUT_PATH IS EMPTY... continue")
                         continue
                 else:
-                    bt.logging.warning(f"OUTPUT_PATH DOES NOT EXIST... continue")
+                    logger.warning(f"OUTPUT_PATH DOES NOT EXIST... continue")
                     continue
 
                 current_state = sim["executor"].get_state()

--- a/tests/test_template_validator.py
+++ b/tests/test_template_validator.py
@@ -93,7 +93,7 @@ class TemplateValidatorNeuronTestCase(unittest.TestCase):
 
     def test_reward_with_nan(self):
         # TODO: Test that NaN rewards are correctly sanitized
-        # TODO: Test that a bt.logging.warning is thrown when a NaN reward is sanitized
+        # TODO: Test that a logger.warning is thrown when a NaN reward is sanitized
         responses = self.dendrite.query(
             # Send the query to miners in the network.
             axons=[self.metagraph.axons[uid] for uid in self.miner_uids],
@@ -108,5 +108,5 @@ class TemplateValidatorNeuronTestCase(unittest.TestCase):
         # Add NaN values to rewards
         rewards[0] = float("nan")
 
-        with self.assertLogs(bt.logging, level="WARNING") as cm:
+        with self.assertLogs(logger, level="WARNING") as cm:
             self.neuron.update_scores(rewards, self.miner_uids)


### PR DESCRIPTION
Add attribute `best_submitted_energy` to the `JobSubmissionSynapse` so miners can use this to compare their loss to the best recorded. 