### PR TITLE
Staging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "folding"
-version = "1.2.1"
+version = "1.2.2"
 description = "Macrocosmos Subnet 25: Folding"
 authors = ["Brian McCrindle <brian@macrocosmos.ai>", "Sergio Champoux <sergio@macrocosmos.ai>", "Szymon Fonau <szymon.fonau@macrocosmos.ai>"]
 


### PR DESCRIPTION
At some point, the Bittensor dendrite got slower and has broken Subnet 25 due to the `PingSynapse` timeout only being 3 seconds to optimize throughput on miner queries. Therefore, we increase this to the same timeout level as the typical forward query to avoid this issue all together. 