### PR TITLE
Fix for exploit where miner can affect the reproduced sim

### DIFF
--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -551,6 +551,10 @@ class Protein(OpenMMSimulation):
         )
 
         check_energies: np.ndarray = check_log_file["Potential Energy (kJ/mole)"].values
+        
+        if len(np.unique(check_energies)) == 1:
+            logger.warning("All energy values in reproduced simulation are the same. Skipping!")
+            return False, [], []
 
         if not self.check_gradient(check_energies=check_energies):
             logger.warning(


### PR DESCRIPTION
## Exploit description

`checked_energy` is the same value for every simulation step, basically mitigating our reproducibility. Meaning miners can modify simulations however they want without us finding out.

## Attempted methods of reproducibility
* Set step size to 0 to freeze the simulation ❌ 
* Set temperature to 0 ❌ 
* Make all velocities 0 ❌ 
* Create a custom integrator that makes all velocities 0 at every simulation step ❌ 
* Added a custom external force that adds the exact opposite of the velocity of each particle ❌ 
* Add a custom external force that will restrain all atoms ❌ 