### PR TITLE
added safely loading checkpoints

### DIFF
--- a/folding/base/simulation.py
+++ b/folding/base/simulation.py
@@ -149,8 +149,17 @@ class OpenMMSimulation(GenericSimulation):
         positions = temp_sim.context.getState(getPositions=True).getPositions()
         velocities = temp_sim.context.getState(getVelocities=True).getVelocities()
         step = temp_sim.currentStep
+        
+        integrator = mm.LangevinIntegrator(
+            system_config["temperature"] * unit.kelvin,
+            system_config["friction"] / unit.picosecond,
+            system_config["time_step_size"] * unit.picoseconds,
+        )
 
-        clean_sim = app.Simulation(modeller.topology, system, temp_sim.integrator, platform, properties)
+        seed = seed if seed is not None else system_config["seed"]
+        integrator.setRandomNumberSeed(seed)
+
+        clean_sim = app.Simulation(modeller.topology, system, integrator, platform, properties)
         clean_sim.context.setPositions(positions)
         clean_sim.context.setVelocities(velocities)
         clean_sim.currentStep = step

--- a/folding/base/simulation.py
+++ b/folding/base/simulation.py
@@ -142,7 +142,7 @@ class OpenMMSimulation(GenericSimulation):
         seed: int = None,
     ) -> Tuple[app.Simulation, SimulationConfig]:
         """Creates a simulation object from a checkpoint file."""
-        temp_sim, system, _, platform, properties = self._prepare_simulation(pdb, system_config, seed)
+        temp_sim, system, modeller, platform, properties = self._prepare_simulation(pdb, system_config, seed)
 
         # Load checkpoint state
         temp_sim.loadCheckpoint(checkpoint_path)
@@ -150,7 +150,7 @@ class OpenMMSimulation(GenericSimulation):
         velocities = temp_sim.context.getState(getVelocities=True).getVelocities()
         step = temp_sim.currentStep
 
-        clean_sim = app.Simulation(system.topology, system, temp_sim.integrator, platform, properties)
+        clean_sim = app.Simulation(modeller.topology, system, temp_sim.integrator, platform, properties)
         clean_sim.context.setPositions(positions)
         clean_sim.context.setVelocities(velocities)
         clean_sim.currentStep = step

--- a/folding/base/simulation.py
+++ b/folding/base/simulation.py
@@ -148,3 +148,105 @@ class OpenMMSimulation(GenericSimulation):
                 system_config[k] = str(v)
 
         return simulation, SimulationConfig(**system_config)
+
+    def create_simulation_from_checkpoint(
+        self,
+        pdb: app.PDBFile,
+        system_config: dict,
+        checkpoint_path: str,
+        seed: int = None,
+    ) -> Tuple[app.Simulation, SimulationConfig]:
+        start_time = time.time()
+        forcefield = app.ForceField(system_config["ff"], system_config["water"])
+        logger.warning(f"Creating ff took {time.time() - start_time:.4f} seconds")
+
+        modeller = app.Modeller(pdb.topology, pdb.positions)
+
+        start_time = time.time()
+        modeller.deleteWater()
+        logger.warning(f"Deleting water took {time.time() - start_time:.4f} seconds")
+
+        # modeller.addExtraParticles(forcefield)
+
+        start_time = time.time()
+        modeller.addHydrogens(forcefield)
+        logger.warning(f"Adding hydrogens took {time.time() - start_time:.4f} seconds")
+
+        start_time = time.time()
+        # modeller.addSolvent(
+        #     forcefield,
+        #     padding=system_config.box_padding * unit.nanometer,
+        #     boxShape=system_config.box,
+        # )
+        logger.warning(f"Adding solvent took {time.time() - start_time:.4f} seconds")
+
+        # Create the system
+        start_time = time.time()
+        # The assumption here is that the system_config cutoff MUST be given in nanometers
+        threshold = (
+            pdb.topology.getUnitCellDimensions().min().value_in_unit(mm.unit.nanometers)
+        ) / 2
+        if system_config["cutoff"] > threshold:
+            nonbondedCutoff = threshold * mm.unit.nanometers
+            # set the attribute in the config for the pipeline.
+            system_config["cutoff"] = threshold
+            logger.warning(
+                f"Nonbonded cutoff is greater than half the minimum box dimension. Setting nonbonded cutoff to {threshold} nm"
+            )
+        else:
+            nonbondedCutoff = system_config["cutoff"] * mm.unit.nanometers
+
+        system = forcefield.createSystem(
+            modeller.topology,
+            nonbondedMethod=mm.app.NoCutoff,
+            nonbondedCutoff=nonbondedCutoff,
+            constraints=system_config["constraints"],
+        )
+        logger.warning(f"Creating system took {time.time() - start_time:.4f} seconds")
+
+        # Integrator settings
+        integrator = mm.LangevinIntegrator(
+            system_config["temperature"] * unit.kelvin,
+            system_config["friction"] / unit.picosecond,
+            system_config["time_step_size"] * unit.picoseconds,
+        )
+
+        seed = seed if seed is not None else system_config["seed"]
+        integrator.setRandomNumberSeed(seed)
+
+        # Periodic boundary conditions
+        # pdb.topology.setPeriodicBoxVectors(system.getDefaultPeriodicBoxVectors())
+
+        # if state != "nvt":
+        #     system.addForce(
+        #         mm.MonteCarloBarostat(
+        #             system_config["pressure"] * unit.bar,
+        #             system_config["temperature"] * unit.kelvin,
+        #         )
+        #     )
+
+        platform = mm.Platform.getPlatformByName("CUDA")
+
+        # Reference for DisablePmeStream: https://github.com/openmm/openmm/issues/3589
+        properties = {
+            "DeterministicForces": "true",
+            "Precision": "double",
+            "DisablePmeStream": "true",
+        }
+
+        temp_sim = app.Simulation(
+            system.topology, system, integrator, platform, properties
+        )
+        temp_sim.loadCheckpoint(checkpoint_path)
+        positions = temp_sim.context.getState(getPositions=True).getPositions()
+        velocities = temp_sim.context.getState(getVelocities=True).getVelocities()
+        step = temp_sim.currentStep
+
+        clean_sim = app.Simulation(
+            system.topology, system, integrator, platform, properties
+        )
+        clean_sim.context.setPositions(positions)
+        clean_sim.context.setVelocities(velocities)
+        clean_sim.currentStep = step
+
+        return clean_sim, SimulationConfig(**system_config)

--- a/folding/base/simulation.py
+++ b/folding/base/simulation.py
@@ -26,31 +26,17 @@ class GenericSimulation(ABC):
             start_time = time.time()
             result = method(*args, **kwargs)
             end_time = time.time()
-            logger.info(
-                f"Method {method.__name__} took {end_time - start_time:.4f} seconds"
-            )
+            logger.info(f"Method {method.__name__} took {end_time - start_time:.4f} seconds")
             return result
 
         return timed
 
 
 class OpenMMSimulation(GenericSimulation):
-    @GenericSimulation.timeit
-    def create_simulation(
+    def _prepare_simulation(
         self, pdb: app.PDBFile, system_config: dict, seed: int = None
-    ) -> Tuple[app.Simulation, SimulationConfig]:
-        """Recreates a simulation object based on the provided parameters.
-
-        This method takes in a seed, state, and checkpoint file path to recreate a simulation object.
-        Args:
-            seed (str): The seed for the random number generator.
-            state (str): The state of the simulation.
-            cpt_file (str): The path to the checkpoint file.
-
-        Returns:
-            app.Simulation: The recreated simulation object.
-            system_config: The potentially altered system configuration in SimulationConfig format.
-        """
+    ) -> Tuple[mm.app.Simulation, mm.System, app.Modeller, mm.Platform, dict]:
+        """Common setup logic for creating OpenMM simulations."""
         start_time = time.time()
         forcefield = app.ForceField(system_config["ff"], system_config["water"])
         logger.warning(f"Creating ff took {time.time() - start_time:.4f} seconds")
@@ -78,9 +64,7 @@ class OpenMMSimulation(GenericSimulation):
         # Create the system
         start_time = time.time()
         # The assumption here is that the system_config cutoff MUST be given in nanometers
-        threshold = (
-            pdb.topology.getUnitCellDimensions().min().value_in_unit(mm.unit.nanometers)
-        ) / 2
+        threshold = (pdb.topology.getUnitCellDimensions().min().value_in_unit(mm.unit.nanometers)) / 2
         if system_config["cutoff"] > threshold:
             nonbondedCutoff = threshold * mm.unit.nanometers
             # set the attribute in the config for the pipeline.
@@ -121,28 +105,29 @@ class OpenMMSimulation(GenericSimulation):
         #     )
 
         platform = mm.Platform.getPlatformByName("CUDA")
-
-        # Reference for DisablePmeStream: https://github.com/openmm/openmm/issues/3589
         properties = {
             "DeterministicForces": "true",
             "Precision": "double",
-            "DisablePmeStream": "true",
+            "DisablePmeStream": "true",  # Reference: https://github.com/openmm/openmm/issues/3589
         }
 
+        simulation = app.Simulation(modeller.topology, system, integrator, platform, properties)
+
+        return simulation, system, modeller, platform, properties
+
+    @GenericSimulation.timeit
+    def create_simulation(
+        self, pdb: app.PDBFile, system_config: dict, seed: int = None
+    ) -> Tuple[app.Simulation, SimulationConfig]:
+        """Creates a new simulation object with the provided parameters."""
         start_time = time.time()
-        simulation = mm.app.Simulation(
-            modeller.topology, system, integrator, platform, properties
-        )
-        logger.warning(
-            f"Creating simulation took {time.time() - start_time:.4f} seconds"
-        )
-        # Set initial positions
+        simulation, _, modeller, _, _ = self._prepare_simulation(pdb, system_config, seed)
 
         start_time = time.time()
         simulation.context.setPositions(modeller.positions)
         logger.warning(f"Setting positions took {time.time() - start_time:.4f} seconds")
 
-        # Converting the system config into a Dict[str,str] and ensure all values in system_config are of the correct type
+        # Convert system_config values to appropriate types
         for k, v in system_config.items():
             if not isinstance(v, (str, int, float, dict)):
                 system_config[k] = str(v)
@@ -156,95 +141,16 @@ class OpenMMSimulation(GenericSimulation):
         checkpoint_path: str,
         seed: int = None,
     ) -> Tuple[app.Simulation, SimulationConfig]:
-        start_time = time.time()
-        forcefield = app.ForceField(system_config["ff"], system_config["water"])
-        logger.warning(f"Creating ff took {time.time() - start_time:.4f} seconds")
+        """Creates a simulation object from a checkpoint file."""
+        temp_sim, system, _, platform, properties = self._prepare_simulation(pdb, system_config, seed)
 
-        modeller = app.Modeller(pdb.topology, pdb.positions)
-
-        start_time = time.time()
-        modeller.deleteWater()
-        logger.warning(f"Deleting water took {time.time() - start_time:.4f} seconds")
-
-        # modeller.addExtraParticles(forcefield)
-
-        start_time = time.time()
-        modeller.addHydrogens(forcefield)
-        logger.warning(f"Adding hydrogens took {time.time() - start_time:.4f} seconds")
-
-        start_time = time.time()
-        # modeller.addSolvent(
-        #     forcefield,
-        #     padding=system_config.box_padding * unit.nanometer,
-        #     boxShape=system_config.box,
-        # )
-        logger.warning(f"Adding solvent took {time.time() - start_time:.4f} seconds")
-
-        # Create the system
-        start_time = time.time()
-        # The assumption here is that the system_config cutoff MUST be given in nanometers
-        threshold = (
-            pdb.topology.getUnitCellDimensions().min().value_in_unit(mm.unit.nanometers)
-        ) / 2
-        if system_config["cutoff"] > threshold:
-            nonbondedCutoff = threshold * mm.unit.nanometers
-            # set the attribute in the config for the pipeline.
-            system_config["cutoff"] = threshold
-            logger.warning(
-                f"Nonbonded cutoff is greater than half the minimum box dimension. Setting nonbonded cutoff to {threshold} nm"
-            )
-        else:
-            nonbondedCutoff = system_config["cutoff"] * mm.unit.nanometers
-
-        system = forcefield.createSystem(
-            modeller.topology,
-            nonbondedMethod=mm.app.NoCutoff,
-            nonbondedCutoff=nonbondedCutoff,
-            constraints=system_config["constraints"],
-        )
-        logger.warning(f"Creating system took {time.time() - start_time:.4f} seconds")
-
-        # Integrator settings
-        integrator = mm.LangevinIntegrator(
-            system_config["temperature"] * unit.kelvin,
-            system_config["friction"] / unit.picosecond,
-            system_config["time_step_size"] * unit.picoseconds,
-        )
-
-        seed = seed if seed is not None else system_config["seed"]
-        integrator.setRandomNumberSeed(seed)
-
-        # Periodic boundary conditions
-        # pdb.topology.setPeriodicBoxVectors(system.getDefaultPeriodicBoxVectors())
-
-        # if state != "nvt":
-        #     system.addForce(
-        #         mm.MonteCarloBarostat(
-        #             system_config["pressure"] * unit.bar,
-        #             system_config["temperature"] * unit.kelvin,
-        #         )
-        #     )
-
-        platform = mm.Platform.getPlatformByName("CUDA")
-
-        # Reference for DisablePmeStream: https://github.com/openmm/openmm/issues/3589
-        properties = {
-            "DeterministicForces": "true",
-            "Precision": "double",
-            "DisablePmeStream": "true",
-        }
-
-        temp_sim = app.Simulation(
-            system.topology, system, integrator, platform, properties
-        )
+        # Load checkpoint state
         temp_sim.loadCheckpoint(checkpoint_path)
         positions = temp_sim.context.getState(getPositions=True).getPositions()
         velocities = temp_sim.context.getState(getVelocities=True).getVelocities()
         step = temp_sim.currentStep
 
-        clean_sim = app.Simulation(
-            system.topology, system, integrator, platform, properties
-        )
+        clean_sim = app.Simulation(system.topology, system, temp_sim.integrator, platform, properties)
         clean_sim.context.setPositions(positions)
         clean_sim.context.setVelocities(velocities)
         clean_sim.currentStep = step

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -98,7 +98,11 @@ class Protein(OpenMMSimulation):
         self.simulation: app.Simulation = None
         self.input_files = [self.em_cpt_location]
 
-        self.md_inputs = self.read_and_return_files(filenames=self.input_files) if load_md_inputs else {}
+        self.md_inputs = (
+            self.read_and_return_files(filenames=self.input_files)
+            if load_md_inputs
+            else {}
+        )
 
         # set to an arbitrarily high number to ensure that the first miner is always accepted.
         self.init_energy = 0
@@ -119,10 +123,16 @@ class Protein(OpenMMSimulation):
         self.pdb_location = os.path.join(self.pdb_directory, self.pdb_file)
 
         self.validator_directory = os.path.join(self.pdb_directory, "validator")
-        self.em_cpt_location = os.path.join(self.validator_directory, self.simulation_cpt)
-        self.simulation_pkl_location = os.path.join(self.validator_directory, self.simulation_pkl)
+        self.em_cpt_location = os.path.join(
+            self.validator_directory, self.simulation_cpt
+        )
+        self.simulation_pkl_location = os.path.join(
+            self.validator_directory, self.simulation_pkl
+        )
 
-        self.velm_array_pkl = os.path.join(self.pdb_directory, "velm_array_indicies.pkl")
+        self.velm_array_pkl = os.path.join(
+            self.pdb_directory, "velm_array_indicies.pkl"
+        )
 
     @staticmethod
     async def from_job(job: Job, config: Dict):
@@ -179,10 +189,14 @@ class Protein(OpenMMSimulation):
                 download=True,
                 force=self.config.force_use_pdb,
             ):
-                raise Exception(f"Failed to download {self.pdb_file} to {self.pdb_directory}")
+                raise Exception(
+                    f"Failed to download {self.pdb_file} to {self.pdb_directory}"
+                )
             await self.fix_pdb_file()
         else:
-            logger.info(f"PDB file {self.pdb_file} already exists in path {self.pdb_directory!r}.")
+            logger.info(
+                f"PDB file {self.pdb_file} already exists in path {self.pdb_directory!r}."
+            )
 
     def read_and_return_files(self, filenames: List) -> Dict:
         """Read the files and return them as a dictionary."""
@@ -194,9 +208,13 @@ class Protein(OpenMMSimulation):
                     name = file.split("/")[-1]
                     with open(file, "rb") as f:
                         if "cpt" in name:
-                            files_to_return[name] = base64.b64encode(f.read()).decode("utf-8")
+                            files_to_return[name] = base64.b64encode(f.read()).decode(
+                                "utf-8"
+                            )
                         else:
-                            files_to_return[name] = f.read()  # This would be the pdb file.
+                            files_to_return[
+                                name
+                            ] = f.read()  # This would be the pdb file.
 
                 except Exception:
                     continue
@@ -235,7 +253,9 @@ class Protein(OpenMMSimulation):
 
         # Checking if init energy is nan
         if np.isnan(self.init_energy):
-            raise OpenMMException(f"Failed to calculate initial energy for {self.pdb_id}")
+            raise OpenMMException(
+                f"Failed to calculate initial energy for {self.pdb_id}"
+            )
 
         self._calculate_epsilon()
 
@@ -325,7 +345,9 @@ class Protein(OpenMMSimulation):
         logger.info(f"Changing path to {self.pdb_directory}")
         os.chdir(self.pdb_directory)
 
-        logger.info(f"pdb file is set to: {self.pdb_file}, and it is located at {self.pdb_location}")
+        logger.info(
+            f"pdb file is set to: {self.pdb_file}, and it is located at {self.pdb_location}"
+        )
 
         self.simulation, self.system_config = await asyncio.to_thread(
             self.create_simulation,
@@ -368,7 +390,9 @@ class Protein(OpenMMSimulation):
         """Generate a random seed"""
         return random.randint(1000, 999999)
 
-    def save_files(self, files: Dict, output_directory: str, write_mode: str = "wb") -> Dict:
+    def save_files(
+        self, files: Dict, output_directory: str, write_mode: str = "wb"
+    ) -> Dict:
         """Save the simulation files generated on the validator side to a desired output directory.
 
         Args:
@@ -405,7 +429,9 @@ class Protein(OpenMMSimulation):
     def get_miner_data_directory(self, hotkey: str):
         self.miner_data_directory = os.path.join(self.validator_directory, hotkey[:8])
 
-    def process_md_output(self, md_output: dict, seed: int, state: str, hotkey: str) -> bool:
+    def process_md_output(
+        self, md_output: dict, seed: int, state: str, hotkey: str
+    ) -> bool:
         MIN_LOGGING_ENTRIES = 500
         MIN_SIMULATION_STEPS = 5000
 
@@ -415,10 +441,14 @@ class Protein(OpenMMSimulation):
         self.miner_seed = seed
 
         # This is just mapper from the file extension to the name of the file stores in the dict.
-        self.md_outputs_exts = {k.split(".")[-1]: k for k, v in md_output.items() if len(v) > 0}
+        self.md_outputs_exts = {
+            k.split(".")[-1]: k for k, v in md_output.items() if len(v) > 0
+        }
 
         if len(md_output.keys()) == 0:
-            logger.warning(f"Miner {self.hotkey_alias} returned empty md_output... Skipping!")
+            logger.warning(
+                f"Miner {self.hotkey_alias} returned empty md_output... Skipping!"
+            )
             return False
 
         for ext in required_files_extensions:
@@ -437,19 +467,19 @@ class Protein(OpenMMSimulation):
             # NOTE: The seed written in the self.system_config is not used here
             # because the miner could have used something different and we want to
             # make sure that we are using the correct seed.
-
-            logger.info(f"Recreating miner {self.hotkey_alias} simulation in state: {self.current_state}")
-            self.simulation, self.system_config = self.create_simulation(
-                pdb=self.load_pdb_file(pdb_file=self.pdb_location),
-                system_config=self.system_config.get_config(),
-                seed=self.miner_seed,
+            checkpoint_path = os.path.join(
+                self.miner_data_directory, f"{self.current_state}.cpt"
+            )
+            state_xml_path = os.path.join(
+                self.miner_data_directory, f"{self.current_state}.xml"
+            )
+            log_file_path = os.path.join(
+                self.miner_data_directory, self.md_outputs_exts["log"]
             )
 
-            checkpoint_path = os.path.join(self.miner_data_directory, f"{self.current_state}.cpt")
-            state_xml_path = os.path.join(self.miner_data_directory, f"{self.current_state}.xml")
-            log_file_path = os.path.join(self.miner_data_directory, self.md_outputs_exts["log"])
-
-            self.simulation.loadCheckpoint(checkpoint_path)
+            logger.info(
+                f"Recreating miner {self.hotkey_alias} simulation in state: {self.current_state}"
+            )
 
             self.log_file = pd.read_csv(log_file_path)
             self.log_step = self.log_file['#"Step"'].iloc[-1]
@@ -460,18 +490,40 @@ class Protein(OpenMMSimulation):
                     f"Miner {self.hotkey_alias} did not run enough steps in the simulation... Skipping!"
                 )
 
+            (
+                self.simulation,
+                self.system_config,
+            ) = self.create_simulation_from_checkpoint(
+                pdb=self.load_pdb_file(pdb_file=self.pdb_location),
+                system_config=self.system_config.get_config(),
+                checkpoint_path=checkpoint_path,
+                seed=self.miner_seed,
+            )
+
             # Make sure that we are enough steps ahead in the log file compared to the checkpoint file.
             # Checks if log_file is MIN_STEPS steps ahead of checkpoint
             if (self.log_step - self.simulation.currentStep) < MIN_SIMULATION_STEPS:
                 # If the miner did not run enough steps, we will load the old checkpoint
-                checkpoint_path = os.path.join(self.miner_data_directory, f"{self.current_state}_old.cpt")
+                checkpoint_path = os.path.join(
+                    self.miner_data_directory, f"{self.current_state}_old.cpt"
+                )
                 if os.path.exists(checkpoint_path):
                     logger.warning(
                         f"Miner {self.hotkey_alias} did not run enough steps since last checkpoint... Loading old checkpoint"
                     )
-                    self.simulation.loadCheckpoint(checkpoint_path)
+                    (
+                        self.simulation,
+                        self.system_config,
+                    ) = self.create_simulation_from_checkpoint(
+                        pdb=self.load_pdb_file(pdb_file=self.pdb_location),
+                        system_config=self.system_config.get_config(),
+                        checkpoint_path=checkpoint_path,
+                        seed=self.miner_seed,
+                    )
                     # Checking to see if the old checkpoint has enough steps to validate
-                    if (self.log_step - self.simulation.currentStep) < MIN_SIMULATION_STEPS:
+                    if (
+                        self.log_step - self.simulation.currentStep
+                    ) < MIN_SIMULATION_STEPS:
                         raise ValidationError(
                             f"Miner {self.hotkey_alias} did not run enough steps in the simulation... Skipping!"
                         )
@@ -488,7 +540,9 @@ class Protein(OpenMMSimulation):
             self.simulation.saveState(self.state_xml_path)
 
             # Save the system config to the miner data directory
-            system_config_path = os.path.join(self.miner_data_directory, f"miner_system_config_{seed}.pkl")
+            system_config_path = os.path.join(
+                self.miner_data_directory, f"miner_system_config_{seed}.pkl"
+            )
             if not os.path.exists(system_config_path):
                 write_pkl(
                     data=self.system_config,
@@ -515,7 +569,9 @@ class Protein(OpenMMSimulation):
         GRADIENT_THRESHOLD = 10  # kJ/mol/nm
 
         mean_gradient = np.diff(check_energies[:WINDOW]).mean().item()
-        return mean_gradient <= GRADIENT_THRESHOLD  # includes large negative gradients is passible
+        return (
+            mean_gradient <= GRADIENT_THRESHOLD
+        )  # includes large negative gradients is passible
 
     def check_masses(self) -> bool:
         """
@@ -534,7 +590,9 @@ class Protein(OpenMMSimulation):
 
         for i, (v_mass, m_mass) in enumerate(zip(validator_masses, miner_masses)):
             if v_mass != m_mass:
-                logger.error(f"Masses for atom {i} do not match. Validator: {v_mass}, Miner: {m_mass}")
+                logger.error(
+                    f"Masses for atom {i} do not match. Validator: {v_mass}, Miner: {m_mass}"
+                )
                 return False
         return True
 
@@ -565,9 +623,10 @@ class Protein(OpenMMSimulation):
         # Run the simulation at most 3000 steps
         steps_to_run = min(3000, self.log_step - self.cpt_step)
 
-
         # This is where we are going to check the xml files for the state.
-        logger.info(f"Recreating simulation for {self.pdb_id} for state-based analysis...")
+        logger.info(
+            f"Recreating simulation for {self.pdb_id} for state-based analysis..."
+        )
         self.simulation, self.system_config = self.create_simulation(
             pdb=self.load_pdb_file(pdb_file=self.pdb_location),
             system_config=self.system_config.get_config(),
@@ -577,13 +636,18 @@ class Protein(OpenMMSimulation):
         state_energies = []
         for _ in range(100):
             self.simulation.step(100)
-            energy = self.simulation.context.getState(getEnergy=True).getPotentialEnergy()._value
+            energy = (
+                self.simulation.context.getState(getEnergy=True)
+                .getPotentialEnergy()
+                ._value
+            )
             state_energies.append(energy)
 
         if not self.check_gradient(check_energies=state_energies):
-            logger.warning(f"hotkey {self.hotkey_alias} failed state-gradient check for {self.pdb_id}, ... Skipping!")
+            logger.warning(
+                f"hotkey {self.hotkey_alias} failed state-gradient check for {self.pdb_id}, ... Skipping!"
+            )
             return False, [], [], "state-gradient"
-
 
         # Reload in the checkpoint file and run the simulation for the same number of steps as the miner.
         self.simulation, self.system_config = self.create_simulation(
@@ -593,7 +657,9 @@ class Protein(OpenMMSimulation):
         )
         self.simulation.loadCheckpoint(self.checkpoint_path)
 
-        current_state_logfile = os.path.join(self.miner_data_directory, f"check_{self.current_state}.log")
+        current_state_logfile = os.path.join(
+            self.miner_data_directory, f"check_{self.current_state}.log"
+        )
         self.simulation.reporters.append(
             app.StateDataReporter(
                 current_state_logfile,
@@ -603,24 +669,31 @@ class Protein(OpenMMSimulation):
             )
         )
 
-        logger.info(f"Running {steps_to_run} steps. log_step: {self.log_step}, cpt_step: {self.cpt_step}")
+        logger.info(
+            f"Running {steps_to_run} steps. log_step: {self.log_step}, cpt_step: {self.cpt_step}"
+        )
 
         max_step = self.cpt_step + steps_to_run
         miner_energies: np.ndarray = self.log_file[
-            (self.log_file['#"Step"'] > self.cpt_step) & (self.log_file['#"Step"'] <= max_step)
+            (self.log_file['#"Step"'] > self.cpt_step)
+            & (self.log_file['#"Step"'] <= max_step)
         ]["Potential Energy (kJ/mole)"].values
 
-        self.simulation.step(steps_to_run)     
+        self.simulation.step(steps_to_run)
 
         check_log_file = pd.read_csv(current_state_logfile)
         check_energies: np.ndarray = check_log_file["Potential Energy (kJ/mole)"].values
 
         if len(np.unique(check_energies)) == 1:
-            logger.warning("All energy values in reproduced simulation are the same. Skipping!")
+            logger.warning(
+                "All energy values in reproduced simulation are the same. Skipping!"
+            )
             return False, [], [], "energies_non_unique"
 
         if not self.check_gradient(check_energies=check_energies):
-            logger.warning(f"hotkey {self.hotkey_alias} failed cpt-gradient check for {self.pdb_id}, ... Skipping!")
+            logger.warning(
+                f"hotkey {self.hotkey_alias} failed cpt-gradient check for {self.pdb_id}, ... Skipping!"
+            )
             return False, [], [], "cpt-gradient"
 
         # calculating absolute percent difference per step
@@ -642,7 +715,11 @@ class Protein(OpenMMSimulation):
             return False, check_energies.tolist(), miner_energies.tolist(), "anomaly"
 
         # Save the folded pdb file if the run is valid
-        self.save_pdb(output_path=os.path.join(self.miner_data_directory, f"{self.pdb_id}_folded.pdb"))
+        self.save_pdb(
+            output_path=os.path.join(
+                self.miner_data_directory, f"{self.pdb_id}_folded.pdb"
+            )
+        )
 
         return True, check_energies.tolist(), miner_energies.tolist(), ""
 
@@ -691,4 +768,7 @@ class Protein(OpenMMSimulation):
             float: potential energy
         """
 
-        return self.simulation.context.getState(getEnergy=True).getPotentialEnergy() / unit.kilojoules_per_mole
+        return (
+            self.simulation.context.getState(getEnergy=True).getPotentialEnergy()
+            / unit.kilojoules_per_mole
+        )

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -592,14 +592,14 @@ class Protein(OpenMMSimulation):
         if not self.check_gradient(check_energies=state_energies):
             logger.warning(f"hotkey {self.hotkey_alias} failed state-gradient check for {self.pdb_id}, ... Skipping!")
             return False, [], [], "state-gradient"
-
+        
         # Reload in the checkpoint file and run the simulation for the same number of steps as the miner.
-        self.simulation, self.system_config = self.create_simulation(
+        self.simulation, self.system_config = self.create_simulation_from_checkpoint(
             pdb=self.load_pdb_file(pdb_file=self.pdb_location),
             system_config=self.system_config.get_config(),
+            checkpoint_path=self.checkpoint_path,
             seed=self.miner_seed,
         )
-        self.simulation.loadCheckpoint(self.checkpoint_path)
 
         current_state_logfile = os.path.join(self.miner_data_directory, f"check_{self.current_state}.log")
         self.simulation.reporters.append(

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -98,11 +98,7 @@ class Protein(OpenMMSimulation):
         self.simulation: app.Simulation = None
         self.input_files = [self.em_cpt_location]
 
-        self.md_inputs = (
-            self.read_and_return_files(filenames=self.input_files)
-            if load_md_inputs
-            else {}
-        )
+        self.md_inputs = self.read_and_return_files(filenames=self.input_files) if load_md_inputs else {}
 
         # set to an arbitrarily high number to ensure that the first miner is always accepted.
         self.init_energy = 0
@@ -123,16 +119,10 @@ class Protein(OpenMMSimulation):
         self.pdb_location = os.path.join(self.pdb_directory, self.pdb_file)
 
         self.validator_directory = os.path.join(self.pdb_directory, "validator")
-        self.em_cpt_location = os.path.join(
-            self.validator_directory, self.simulation_cpt
-        )
-        self.simulation_pkl_location = os.path.join(
-            self.validator_directory, self.simulation_pkl
-        )
+        self.em_cpt_location = os.path.join(self.validator_directory, self.simulation_cpt)
+        self.simulation_pkl_location = os.path.join(self.validator_directory, self.simulation_pkl)
 
-        self.velm_array_pkl = os.path.join(
-            self.pdb_directory, "velm_array_indicies.pkl"
-        )
+        self.velm_array_pkl = os.path.join(self.pdb_directory, "velm_array_indicies.pkl")
 
     @staticmethod
     async def from_job(job: Job, config: Dict):
@@ -189,14 +179,10 @@ class Protein(OpenMMSimulation):
                 download=True,
                 force=self.config.force_use_pdb,
             ):
-                raise Exception(
-                    f"Failed to download {self.pdb_file} to {self.pdb_directory}"
-                )
+                raise Exception(f"Failed to download {self.pdb_file} to {self.pdb_directory}")
             await self.fix_pdb_file()
         else:
-            logger.info(
-                f"PDB file {self.pdb_file} already exists in path {self.pdb_directory!r}."
-            )
+            logger.info(f"PDB file {self.pdb_file} already exists in path {self.pdb_directory!r}.")
 
     def read_and_return_files(self, filenames: List) -> Dict:
         """Read the files and return them as a dictionary."""
@@ -208,13 +194,9 @@ class Protein(OpenMMSimulation):
                     name = file.split("/")[-1]
                     with open(file, "rb") as f:
                         if "cpt" in name:
-                            files_to_return[name] = base64.b64encode(f.read()).decode(
-                                "utf-8"
-                            )
+                            files_to_return[name] = base64.b64encode(f.read()).decode("utf-8")
                         else:
-                            files_to_return[
-                                name
-                            ] = f.read()  # This would be the pdb file.
+                            files_to_return[name] = f.read()  # This would be the pdb file.
 
                 except Exception:
                     continue
@@ -253,9 +235,7 @@ class Protein(OpenMMSimulation):
 
         # Checking if init energy is nan
         if np.isnan(self.init_energy):
-            raise OpenMMException(
-                f"Failed to calculate initial energy for {self.pdb_id}"
-            )
+            raise OpenMMException(f"Failed to calculate initial energy for {self.pdb_id}")
 
         self._calculate_epsilon()
 
@@ -345,9 +325,7 @@ class Protein(OpenMMSimulation):
         logger.info(f"Changing path to {self.pdb_directory}")
         os.chdir(self.pdb_directory)
 
-        logger.info(
-            f"pdb file is set to: {self.pdb_file}, and it is located at {self.pdb_location}"
-        )
+        logger.info(f"pdb file is set to: {self.pdb_file}, and it is located at {self.pdb_location}")
 
         self.simulation, self.system_config = await asyncio.to_thread(
             self.create_simulation,
@@ -390,9 +368,7 @@ class Protein(OpenMMSimulation):
         """Generate a random seed"""
         return random.randint(1000, 999999)
 
-    def save_files(
-        self, files: Dict, output_directory: str, write_mode: str = "wb"
-    ) -> Dict:
+    def save_files(self, files: Dict, output_directory: str, write_mode: str = "wb") -> Dict:
         """Save the simulation files generated on the validator side to a desired output directory.
 
         Args:
@@ -429,9 +405,7 @@ class Protein(OpenMMSimulation):
     def get_miner_data_directory(self, hotkey: str):
         self.miner_data_directory = os.path.join(self.validator_directory, hotkey[:8])
 
-    def process_md_output(
-        self, md_output: dict, seed: int, state: str, hotkey: str
-    ) -> bool:
+    def process_md_output(self, md_output: dict, seed: int, state: str, hotkey: str) -> bool:
         MIN_LOGGING_ENTRIES = 500
         MIN_SIMULATION_STEPS = 5000
 
@@ -441,14 +415,10 @@ class Protein(OpenMMSimulation):
         self.miner_seed = seed
 
         # This is just mapper from the file extension to the name of the file stores in the dict.
-        self.md_outputs_exts = {
-            k.split(".")[-1]: k for k, v in md_output.items() if len(v) > 0
-        }
+        self.md_outputs_exts = {k.split(".")[-1]: k for k, v in md_output.items() if len(v) > 0}
 
         if len(md_output.keys()) == 0:
-            logger.warning(
-                f"Miner {self.hotkey_alias} returned empty md_output... Skipping!"
-            )
+            logger.warning(f"Miner {self.hotkey_alias} returned empty md_output... Skipping!")
             return False
 
         for ext in required_files_extensions:
@@ -467,19 +437,11 @@ class Protein(OpenMMSimulation):
             # NOTE: The seed written in the self.system_config is not used here
             # because the miner could have used something different and we want to
             # make sure that we are using the correct seed.
-            checkpoint_path = os.path.join(
-                self.miner_data_directory, f"{self.current_state}.cpt"
-            )
-            state_xml_path = os.path.join(
-                self.miner_data_directory, f"{self.current_state}.xml"
-            )
-            log_file_path = os.path.join(
-                self.miner_data_directory, self.md_outputs_exts["log"]
-            )
+            checkpoint_path = os.path.join(self.miner_data_directory, f"{self.current_state}.cpt")
+            state_xml_path = os.path.join(self.miner_data_directory, f"{self.current_state}.xml")
+            log_file_path = os.path.join(self.miner_data_directory, self.md_outputs_exts["log"])
 
-            logger.info(
-                f"Recreating miner {self.hotkey_alias} simulation in state: {self.current_state}"
-            )
+            logger.info(f"Recreating miner {self.hotkey_alias} simulation in state: {self.current_state}")
 
             self.log_file = pd.read_csv(log_file_path)
             self.log_step = self.log_file['#"Step"'].iloc[-1]
@@ -504,9 +466,7 @@ class Protein(OpenMMSimulation):
             # Checks if log_file is MIN_STEPS steps ahead of checkpoint
             if (self.log_step - self.simulation.currentStep) < MIN_SIMULATION_STEPS:
                 # If the miner did not run enough steps, we will load the old checkpoint
-                checkpoint_path = os.path.join(
-                    self.miner_data_directory, f"{self.current_state}_old.cpt"
-                )
+                checkpoint_path = os.path.join(self.miner_data_directory, f"{self.current_state}_old.cpt")
                 if os.path.exists(checkpoint_path):
                     logger.warning(
                         f"Miner {self.hotkey_alias} did not run enough steps since last checkpoint... Loading old checkpoint"
@@ -521,9 +481,7 @@ class Protein(OpenMMSimulation):
                         seed=self.miner_seed,
                     )
                     # Checking to see if the old checkpoint has enough steps to validate
-                    if (
-                        self.log_step - self.simulation.currentStep
-                    ) < MIN_SIMULATION_STEPS:
+                    if (self.log_step - self.simulation.currentStep) < MIN_SIMULATION_STEPS:
                         raise ValidationError(
                             f"Miner {self.hotkey_alias} did not run enough steps in the simulation... Skipping!"
                         )
@@ -540,9 +498,7 @@ class Protein(OpenMMSimulation):
             self.simulation.saveState(self.state_xml_path)
 
             # Save the system config to the miner data directory
-            system_config_path = os.path.join(
-                self.miner_data_directory, f"miner_system_config_{seed}.pkl"
-            )
+            system_config_path = os.path.join(self.miner_data_directory, f"miner_system_config_{seed}.pkl")
             if not os.path.exists(system_config_path):
                 write_pkl(
                     data=self.system_config,
@@ -569,9 +525,7 @@ class Protein(OpenMMSimulation):
         GRADIENT_THRESHOLD = 10  # kJ/mol/nm
 
         mean_gradient = np.diff(check_energies[:WINDOW]).mean().item()
-        return (
-            mean_gradient <= GRADIENT_THRESHOLD
-        )  # includes large negative gradients is passible
+        return mean_gradient <= GRADIENT_THRESHOLD  # includes large negative gradients is passible
 
     def check_masses(self) -> bool:
         """
@@ -590,9 +544,7 @@ class Protein(OpenMMSimulation):
 
         for i, (v_mass, m_mass) in enumerate(zip(validator_masses, miner_masses)):
             if v_mass != m_mass:
-                logger.error(
-                    f"Masses for atom {i} do not match. Validator: {v_mass}, Miner: {m_mass}"
-                )
+                logger.error(f"Masses for atom {i} do not match. Validator: {v_mass}, Miner: {m_mass}")
                 return False
         return True
 
@@ -624,9 +576,7 @@ class Protein(OpenMMSimulation):
         steps_to_run = min(3000, self.log_step - self.cpt_step)
 
         # This is where we are going to check the xml files for the state.
-        logger.info(
-            f"Recreating simulation for {self.pdb_id} for state-based analysis..."
-        )
+        logger.info(f"Recreating simulation for {self.pdb_id} for state-based analysis...")
         self.simulation, self.system_config = self.create_simulation(
             pdb=self.load_pdb_file(pdb_file=self.pdb_location),
             system_config=self.system_config.get_config(),
@@ -636,17 +586,11 @@ class Protein(OpenMMSimulation):
         state_energies = []
         for _ in range(100):
             self.simulation.step(100)
-            energy = (
-                self.simulation.context.getState(getEnergy=True)
-                .getPotentialEnergy()
-                ._value
-            )
+            energy = self.simulation.context.getState(getEnergy=True).getPotentialEnergy()._value
             state_energies.append(energy)
 
         if not self.check_gradient(check_energies=state_energies):
-            logger.warning(
-                f"hotkey {self.hotkey_alias} failed state-gradient check for {self.pdb_id}, ... Skipping!"
-            )
+            logger.warning(f"hotkey {self.hotkey_alias} failed state-gradient check for {self.pdb_id}, ... Skipping!")
             return False, [], [], "state-gradient"
 
         # Reload in the checkpoint file and run the simulation for the same number of steps as the miner.
@@ -657,9 +601,7 @@ class Protein(OpenMMSimulation):
         )
         self.simulation.loadCheckpoint(self.checkpoint_path)
 
-        current_state_logfile = os.path.join(
-            self.miner_data_directory, f"check_{self.current_state}.log"
-        )
+        current_state_logfile = os.path.join(self.miner_data_directory, f"check_{self.current_state}.log")
         self.simulation.reporters.append(
             app.StateDataReporter(
                 current_state_logfile,
@@ -669,14 +611,11 @@ class Protein(OpenMMSimulation):
             )
         )
 
-        logger.info(
-            f"Running {steps_to_run} steps. log_step: {self.log_step}, cpt_step: {self.cpt_step}"
-        )
+        logger.info(f"Running {steps_to_run} steps. log_step: {self.log_step}, cpt_step: {self.cpt_step}")
 
         max_step = self.cpt_step + steps_to_run
         miner_energies: np.ndarray = self.log_file[
-            (self.log_file['#"Step"'] > self.cpt_step)
-            & (self.log_file['#"Step"'] <= max_step)
+            (self.log_file['#"Step"'] > self.cpt_step) & (self.log_file['#"Step"'] <= max_step)
         ]["Potential Energy (kJ/mole)"].values
 
         self.simulation.step(steps_to_run)
@@ -685,15 +624,11 @@ class Protein(OpenMMSimulation):
         check_energies: np.ndarray = check_log_file["Potential Energy (kJ/mole)"].values
 
         if len(np.unique(check_energies)) == 1:
-            logger.warning(
-                "All energy values in reproduced simulation are the same. Skipping!"
-            )
+            logger.warning("All energy values in reproduced simulation are the same. Skipping!")
             return False, [], [], "energies_non_unique"
 
         if not self.check_gradient(check_energies=check_energies):
-            logger.warning(
-                f"hotkey {self.hotkey_alias} failed cpt-gradient check for {self.pdb_id}, ... Skipping!"
-            )
+            logger.warning(f"hotkey {self.hotkey_alias} failed cpt-gradient check for {self.pdb_id}, ... Skipping!")
             return False, [], [], "cpt-gradient"
 
         # calculating absolute percent difference per step
@@ -715,11 +650,7 @@ class Protein(OpenMMSimulation):
             return False, check_energies.tolist(), miner_energies.tolist(), "anomaly"
 
         # Save the folded pdb file if the run is valid
-        self.save_pdb(
-            output_path=os.path.join(
-                self.miner_data_directory, f"{self.pdb_id}_folded.pdb"
-            )
-        )
+        self.save_pdb(output_path=os.path.join(self.miner_data_directory, f"{self.pdb_id}_folded.pdb"))
 
         return True, check_energies.tolist(), miner_energies.tolist(), ""
 
@@ -768,7 +699,4 @@ class Protein(OpenMMSimulation):
             float: potential energy
         """
 
-        return (
-            self.simulation.context.getState(getEnergy=True).getPotentialEnergy()
-            / unit.kilojoules_per_mole
-        )
+        return self.simulation.context.getState(getEnergy=True).getPotentialEnergy() / unit.kilojoules_per_mole


### PR DESCRIPTION
As noticed by @loayei, loading of the whole checkpoint file with all the information saved in it exposes us to potential dangers.

The implemented approach is a 2 simulations method proposed by @loayei where we create a temporary simulation that loads in the checkpoint and copies all the necessary information (positions, velocities, step) and loads those values into a fresh simulation object