### PR TITLE
Features/remove miner serving

### DIFF
--- a/folding/miners/folding_miner.py
+++ b/folding/miners/folding_miner.py
@@ -280,10 +280,7 @@ class FoldingMiner(BaseMinerNeuron):
                 )
 
                 logger.warning(f"❗ Removing miner from job pool ❗")
-
                 event["condition"] = "cpu_limit_reached"
-                synapse.miner_serving = False
-
                 return check_synapse(self=self, synapse=synapse, event=event)
 
         # The set of RUNNING simulations.
@@ -327,7 +324,6 @@ class FoldingMiner(BaseMinerNeuron):
                     # If the state is failed, we should not return the files.
                     if state == "failed":
                         synapse.miner_state = state
-                        synapse.miner_serving = False
                         event["condition"] = "failed_simulation"
                         event["state"] = state
                         logger.warning(

--- a/folding/protocol.py
+++ b/folding/protocol.py
@@ -41,7 +41,6 @@ class JobSubmissionSynapse(bt.Synapse):
     - pdb_id: A Protein id, which contains the necessary details of the protein to be folded.
     - md_inputs: A dictionary containing the input files for the openmm simulation.
     - system_config: A dictionary containing the system configuration for the simulation.
-    - miner_serving: A boolean value which determines if the miner can serve the request.
     - md_output: A dictionary containing the output files of the openmm simulation.
     - miner_seed: An integer value which is the seed for the simulation.
     - miner_state: A string value which is the state of the miner.
@@ -51,9 +50,6 @@ class JobSubmissionSynapse(bt.Synapse):
     pdb_contents: str
     md_inputs: dict  # Right now this is just a "em.cpt" file.
     system_config: dict = {}
-
-    # Miner can decide if they are serving the request or not.
-    miner_serving: bool = True
 
     best_submitted_energy: typing.Optional[float] = None
 

--- a/folding/utils/ops.py
+++ b/folding/utils/ops.py
@@ -289,7 +289,6 @@ def get_response_info(responses: List[JobSubmissionSynapse]) -> Dict:
     response_status_codes = []
     response_returned_files = []
     response_returned_files_sizes = []
-    response_miners_serving = []
 
     for resp in responses:
         if resp.dendrite.process_time != None:
@@ -301,7 +300,6 @@ def get_response_info(responses: List[JobSubmissionSynapse]) -> Dict:
         response_status_codes.append(str(resp.dendrite.status_code))
         response_returned_files.append(list(resp.md_output.keys()))
         response_returned_files_sizes.append(list(map(len, resp.md_output.values())))
-        response_miners_serving.append(resp.miner_serving)
 
     return {
         "response_times": response_times,
@@ -309,7 +307,6 @@ def get_response_info(responses: List[JobSubmissionSynapse]) -> Dict:
         "response_status_codes": response_status_codes,
         "response_returned_files": response_returned_files,
         "response_returned_files_sizes": response_returned_files_sizes,
-        "response_miners_serving": response_miners_serving,
     }
 
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -281,12 +281,6 @@ class Validator(BaseValidatorNeuron):
         top_reward = 0.80
         apply_pipeline = False
 
-        # There could be hotkeys that have decided to stop serving. We need to remove them from the store.
-        serving_hotkeys = []
-        for ii, state in enumerate(job.event["response_miners_serving"]):
-            if state:
-                serving_hotkeys.append(job.hotkeys[ii])
-
         energies = torch.Tensor(job.event["energies"])
         rewards = torch.zeros(len(energies))  # one-hot per update step
 
@@ -299,10 +293,10 @@ class Validator(BaseValidatorNeuron):
 
         best_index = np.argmin(energies)
         best_loss = energies[best_index].item()  # item because it's a torch.tensor
-        best_hotkey = serving_hotkeys[best_index]
+        best_hotkey = job.hotkeys[best_index]
 
         await job.update(
-            hotkeys=serving_hotkeys,
+            hotkeys=job.hotkeys,
             loss=best_loss,
             hotkey=best_hotkey,
         )


### PR DESCRIPTION
There is an issue with the miner serving flag that causes indexing errors on the validator side. Ideally, we want miners to be able to deny / stop working on jobs, but with the creation of the future Global Job Pool, this feature is not important. Therefore, for quick stability purposes, we are removing this. 