### PR TITLE
refactor linear_reward.py to use weighted distribution for rewards

### DIFF
--- a/folding/rewards/linear_reward.py
+++ b/folding/rewards/linear_reward.py
@@ -4,15 +4,13 @@ from typing import List
 def divide_decreasing(
     amount_to_distribute: float, number_of_elements: int
 ) -> List[float]:
-    # Calculate the fixed decrease amount d
-    d = 2 * amount_to_distribute / ((number_of_elements - 1) * number_of_elements)
+    # Instead of going from n to 0, we go from n to 1
+    # This gives us weights that look like [n, n-1, n-2, ..., 1]
+    weights = [number_of_elements - i for i in range(number_of_elements)]
 
-    # Calculate the first value a1
-    a1 = (
-        amount_to_distribute + d * (number_of_elements - 1) * number_of_elements / 2
-    ) / number_of_elements
+    # Calculate scaling factor to make weights sum to amount_to_distribute
+    total_weight = sum(weights)
+    scaling_factor = amount_to_distribute / total_weight
 
-    # Calculate the n values
-    values = [a1 - i * d for i in range(number_of_elements)]
-
-    return values
+    # Scale all weights proportionally
+    return [w * scaling_factor for w in weights]


### PR DESCRIPTION
Replaces the linearly decreasing function. The new function assigns values to every element (no 0s) This means miners will always receive reward if they are in the top 5.
Mathematical definition of the new function:

$$a_i = A \cdot \frac{2(n-i)}{n(n+1)}$$

where 
* $A$ is the amount to distribute
* $n$ is the number of elements
* $i$ is the index (0 to $n$-1)