### PR TITLE
Fix/validator force restart

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -603,7 +603,7 @@ class Validator(BaseValidatorNeuron):
             block_difference = (
                 self.metagraph.block - self.metagraph.neurons[self.uid].last_update
             )
-            if block_difference > 2 * self.config.neuron.epoch_length:
+            if block_difference > 3 * self.config.neuron.epoch_length:
                 logger.error(
                     f"Haven't set blocks in {block_difference} blocks. Restarting validator."
                 )

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -600,6 +600,15 @@ class Validator(BaseValidatorNeuron):
                 )
                 self.should_exit = True
 
+            block_difference = (
+                self.metagraph.block - self.metagraph.neurons[self.uid].last_update
+            )
+            if block_difference > 2 * self.config.neuron.epoch_length:
+                logger.error(
+                    f"Haven't set blocks in {block_difference} blocks. Restarting validator."
+                )
+                self.should_exit = True
+
     async def __aenter__(self):
         await self.start_rqlite()
         await asyncio.sleep(10)  # Wait for rqlite to start

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -566,8 +566,11 @@ class Validator(BaseValidatorNeuron):
         logger.info("Starting sync loop.")
         while True:
             seconds_per_block = 12
-            await asyncio.sleep(self.config.neuron.epoch_length * seconds_per_block)
-            self.sync()
+            try:
+                await asyncio.sleep(self.config.neuron.epoch_length * seconds_per_block)
+                self.sync()
+            except Exception as e:
+                logger.error(f"Error in sync_loop: {traceback.format_exc()}")
 
     async def monitor_db(self):
         """


### PR DESCRIPTION
If we haven't set weights in a while, we should just force restart the validator since there is likely an issue with the sync_loop