### PR TITLE
Fix solvent

### DIFF
--- a/folding/base/simulation.py
+++ b/folding/base/simulation.py
@@ -64,7 +64,7 @@ class OpenMMSimulation(GenericSimulation):
 
         modeller = app.Modeller(pdb.topology, pdb.positions)
 
-        if use_solvent:
+        if initialize_with_solvent:
             start_time = time.time()
             modeller.deleteWater()
             setup_times["delete_water"] = time.time() - start_time

--- a/folding/base/simulation.py
+++ b/folding/base/simulation.py
@@ -37,7 +37,12 @@ class GenericSimulation(ABC):
 class OpenMMSimulation(GenericSimulation):
     @GenericSimulation.timeit
     def create_simulation(
-        self, pdb: app.PDBFile, system_config: dict, seed: int = None, verbose=False
+        self,
+        pdb: app.PDBFile,
+        system_config: dict,
+        seed: int = None,
+        verbose=False,
+        initialize_with_solvent=False,
     ) -> Tuple[app.Simulation, SimulationConfig]:
         """Recreates a simulation object based on the provided parameters.
 
@@ -46,6 +51,7 @@ class OpenMMSimulation(GenericSimulation):
             seed (str): The seed for the random number generator.
             system_config (dict): A dictionary containing the system configuration settings.
             pdb (app.PDBFile): The PDB file used to initialize the simulation
+            initialize_with_solvent (bool): A boolean flag to determine if the simulation should be initialized with solvent.
 
         Returns:
         Tuple[app.Simulation, SimulationConfig]: A tuple containing the recreated simulation object and the potentially altered system configuration in SystemConfig format.
@@ -58,23 +64,24 @@ class OpenMMSimulation(GenericSimulation):
 
         modeller = app.Modeller(pdb.topology, pdb.positions)
 
-        start_time = time.time()
-        modeller.deleteWater()
-        setup_times["delete_water"] = time.time() - start_time
+        if use_solvent:
+            start_time = time.time()
+            modeller.deleteWater()
+            setup_times["delete_water"] = time.time() - start_time
 
-        # modeller.addExtraParticles(forcefield)
+            start_time = time.time()
+            modeller.addHydrogens(forcefield)
+            setup_times["add_hydrogens"] = time.time() - start_time
 
-        start_time = time.time()
-        modeller.addHydrogens(forcefield)
-        setup_times["add_hydrogens"] = time.time() - start_time
+            start_time = time.time()
+            modeller.addSolvent(
+                forcefield,
+                padding=system_config["box_padding"] * unit.nanometer,
+                boxShape=system_config["box"],
+            )
+            setup_times["add_solvent"] = time.time() - start_time
 
-        start_time = time.time()
-        modeller.addSolvent(
-            forcefield,
-            padding=system_config["box_padding"] * unit.nanometer,
-            boxShape=system_config["box"],
-        )
-        setup_times["add_solvent"] = time.time() - start_time
+            modeller.addExtraParticles(forcefield)
 
         # Create the system
         start_time = time.time()

--- a/folding/registries/evaluation_registry.py
+++ b/folding/registries/evaluation_registry.py
@@ -105,6 +105,7 @@ class SyntheticMDEvaluator(BaseEvaluator):
                 pdb=load_pdb_file(pdb_file=self.pdb_location),
                 system_config=self.system_config.get_config(),
                 seed=self.miner_seed,
+                initialize_with_solvent=False,
             )
 
             checkpoint_path = os.path.join(
@@ -276,6 +277,7 @@ class SyntheticMDEvaluator(BaseEvaluator):
             pdb=load_pdb_file(pdb_file=self.pdb_location),
             system_config=self.system_config.get_config(),
             seed=self.miner_seed,
+            initialize_with_solvent=False,
         )
         simulation.loadState(self.state_xml_path)
         state_energies = []
@@ -299,6 +301,7 @@ class SyntheticMDEvaluator(BaseEvaluator):
                 pdb=load_pdb_file(pdb_file=self.pdb_location),
                 system_config=self.system_config.get_config(),
                 seed=self.miner_seed,
+                initialize_with_solvent=False,
             )
             simulation.loadCheckpoint(self.checkpoint_path)
 

--- a/folding/registries/evaluation_registry.py
+++ b/folding/registries/evaluation_registry.py
@@ -357,7 +357,7 @@ class SyntheticMDEvaluator(BaseEvaluator):
 
             if median_percent_diff > c.ANOMALY_THRESHOLD:
                 logger.warning(
-                    f"hotkey {self.hotkey_alias} failed anomaly check for {self.pdb_id}, ... Skipping!"
+                    f"hotkey {self.hotkey_alias} failed anomaly check for {self.pdb_id}, with median percent difference: {median_percent_diff} ... Skipping!"
                 )
                 raise ValidationError(message="anomaly")
 

--- a/folding/utils/ops.py
+++ b/folding/utils/ops.py
@@ -425,3 +425,21 @@ def create_velm(simulation: app.Simulation) -> Dict[str, Any]:
     }
 
     return velm
+
+
+def write_pdb_file(
+    pdb_location_path: str,
+    topology,
+    positions,
+    suffix: str = "_original",
+):
+    """Write the pdb file using the topology and positions."""
+
+    original_pdb = pdb_location_path.split(".")[0] + f"{suffix}.pdb"
+    os.rename(pdb_location_path, original_pdb)
+
+    app.PDBFile.writeFile(
+        topology=topology,
+        positions=positions,
+        file=open(pdb_location_path, "w"),
+    )

--- a/folding/validators/protein.py
+++ b/folding/validators/protein.py
@@ -274,7 +274,7 @@ class Protein(OpenMMSimulation):
         fixer.addMissingHydrogens(pH=7.0)
 
         write_pdb_file(
-            pdb_file=self.pdb_location,
+            pdb_location_path=self.pdb_location,
             topology=fixer.topology,
             positions=fixer.positions,
             suffix="_original",
@@ -306,7 +306,7 @@ class Protein(OpenMMSimulation):
         state = self.simulation.context.getState(getPositions=True)
         positions = state.getPositions()
         write_pdb_file(
-            pdb_file=self.pdb_location,
+            pdb_location_path=self.pdb_location,
             topology=self.simulation.topology,
             positions=positions,
             suffix="_before_solvent",

--- a/folding/validators/reward.py
+++ b/folding/validators/reward.py
@@ -156,9 +156,15 @@ def get_energies(
     unique_energies = set()  # Track unique energy values
 
     # Process responses until we get TOP_K valid non-duplicate ones or run out of responses
-    for i, (reported_energy, response, uid, evaluator, seed, best_cpt, process_md_output_time) in enumerate(
-        sorted_data
-    ):
+    for i, (
+        reported_energy,
+        response,
+        uid,
+        evaluator,
+        seed,
+        best_cpt,
+        process_md_output_time,
+    ) in enumerate(sorted_data):
         try:
             i = uids.index(uid)
             if reported_energy == 0:
@@ -186,8 +192,12 @@ def get_energies(
 
             if is_valid:
 
-                if not abs(median_energy - reported_energy) < c.DIFFERENCE_THRESHOLD:
+                if (
+                    not abs((median_energy - reported_energy) / reported_energy) * 100
+                    < c.ANOMALY_THRESHOLD
+                ):
                     event["is_valid"][i] = False
+                    event["reason"][i] = "Energy difference too large"
                     continue
 
                 is_duplicate = any(


### PR DESCRIPTION
include initialize_with_solvent which includes solvent during initial simulation creation. Adding the solvent is a non-deterministic process that should only be done once, at the time of simulation creation from the validator. All reloading of the simulation should be done using the pdb _after_ solvent was added. 

At times, we have seen the pdb grow to as much as 300x larger compared to the original, non-solvent counterpart.