### PR TITLE
remove idea of a participation synapse

### DIFF
--- a/folding/base/miner.py
+++ b/folding/base/miner.py
@@ -1,13 +1,11 @@
-import time
 import asyncio
 import threading
 import argparse
-import traceback
 
 import bittensor as bt
 
 from folding.base.neuron import BaseNeuron
-from folding.protocol import PingSynapse, ParticipationSynapse
+from folding.protocol import PingSynapse
 from folding.utils.config import add_miner_args
 from folding.utils.logger import logger
 
@@ -49,8 +47,6 @@ class BaseMinerNeuron(BaseNeuron):
             priority_fn=self.priority,
         ).attach(
             forward_fn=self.ping_forward,  # not sure if we need blacklist on this.
-        ).attach(
-            forward_fn=self.participation_forward,
         )
         logger.info(f"Axon created: {self.axon}")
 
@@ -76,14 +72,6 @@ class BaseMinerNeuron(BaseNeuron):
             synapse.can_serve = True
             logger.success("Telling validator you can serve ✅")
         return synapse
-
-    def participation_forward(self, synapse: ParticipationSynapse):
-        """Respond to the validator with the necessary information about participating in a specified job
-
-        Args:
-            self (ParticipationSynapse): must attach "is_participating"
-        """
-        pass
 
     def run(self):
         pass

--- a/folding/protocol.py
+++ b/folding/protocol.py
@@ -29,13 +29,6 @@ class PingSynapse(bt.Synapse):
     available_compute: typing.Optional[int] = None  # TODO: number of threads / gpus?
 
 
-class ParticipationSynapse(bt.Synapse):
-    """Responsible for determining if a miner is participating in a specific job"""
-
-    job_id: str
-    is_participating: bool = False
-
-
 class JobSubmissionSynapse(bt.Synapse):
     """
     A protocol representation which uses bt.Synapse as its base.

--- a/folding/utils/uids.py
+++ b/folding/utils/uids.py
@@ -6,18 +6,22 @@ from folding.utils.logger import logger
 
 
 def check_uid_availability(
-    metagraph: "bt.metagraph.Metagraph", uid: int, vpermit_tao_limit: int
+    metagraph: "bt.metagraph.Metagraph",
+    uid: int,
+    vpermit_tao_limit: int,
+    include_serving_in_check: bool = True,
 ) -> bool:
     """Check if uid is available. The UID should be available if it is serving and has less than vpermit_tao_limit stake
     Args:
         metagraph (:obj: bt.metagraph.Metagraph): Metagraph object
         uid (int): uid to be checked
         vpermit_tao_limit (int): Validator permit tao limit
+        include_serving_in_check (bool): To only include uids that are serving in the check.
     Returns:
         bool: True if uid is available, False otherwise
     """
     # Filter non serving axons.
-    if not metagraph.axons[uid].is_serving:
+    if include_serving_in_check and not metagraph.axons[uid].is_serving:
         return False
     # Filter validator permit > 1024 stake.
     if metagraph.S[uid] > vpermit_tao_limit:
@@ -61,15 +65,19 @@ def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.LongTensor
     return uids
 
 
-def get_all_miner_uids(self):
+def get_all_miner_uids(self, include_serving_in_check: bool = True):
     """Returns all available miner uids from the metagraph.
     Returns:
         uids (List): All available miner uids.
+        include_serving_in_check (bool): To only include miners that are actually serving in the check.
     """
     candidate_uids = []
     for uid in range(self.metagraph.n.item()):
         uid_is_available = check_uid_availability(
-            self.metagraph, uid, self.config.neuron.vpermit_tao_limit
+            self.metagraph,
+            uid,
+            self.config.neuron.vpermit_tao_limit,
+            include_serving_in_check=include_serving_in_check,
         )
         if uid_is_available:
             candidate_uids.append(uid)


### PR DESCRIPTION
There is a dynamic that has emerged within Folding where miners can turn off their participation once they have gotten near the top of the incentive curve because we do not negatively impact them for not participating. Therefore, we now query _all_ miners when a job's `time to live` parameter is up. 

The PR: 
1. removes the `ParticipationSynapse` from the system entirely
2. removes some old, unused code