### PR TITLE
Asymmetric Weight Scoring

### DIFF
--- a/folding/base/validator.py
+++ b/folding/base/validator.py
@@ -234,12 +234,21 @@ class BaseValidatorNeuron(BaseNeuron):
             0, uids_tensor, rewards
         ).to(self.device)
 
-        # Update scores with rewards produced by this step.
-        # shape: [ metagraph.n ]
-        alpha: float = self.config.neuron.moving_average_alpha
-        self.scores: torch.FloatTensor = alpha * scattered_rewards + (
-            1 - alpha
-        ) * self.scores.to(self.device)
+        # Matrix for alpha values
+        scattered_alpha = torch.zeros_like(self.scores).to(self.device)
+
+        for ii, uid in enumerate(uids_tensor):
+            alpha = (
+                self.config.neuron.positive_alpha
+                if rewards[ii] > 0
+                else self.config.neuron.negative_alpha
+            )
+            scattered_alpha[uid] = alpha
+
+        # Update scores using exponential moving average
+        self.scores: torch.FloatTensor = (
+            scattered_alpha * scattered_rewards + (1 - scattered_alpha) * self.scores
+        )
 
     def save_state(self):
         """Saves the state of the validator to a file."""

--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -341,14 +341,14 @@ def add_validator_args(cls, parser):
     parser.add_argument(
         "--neuron.positive_alpha",
         type=float,
-        help="Moving average alpha parameter, how much to add of the new observation.",
+        help="Positive alpha parameter, how much to add of the new observation when the reward is positive.",
         default=0.10,
     )
 
     parser.add_argument(
         "--neuron.negative_alpha",
         type=float,
-        help="Moving average alpha parameter, how much to add of the new observation.",
+        help="Negative alpha parameter, how much to add of the new observation when the reward is 0.",
         default=0.03,
     )
 

--- a/folding/utils/config.py
+++ b/folding/utils/config.py
@@ -339,10 +339,17 @@ def add_validator_args(cls, parser):
     )
 
     parser.add_argument(
-        "--neuron.moving_average_alpha",
+        "--neuron.positive_alpha",
         type=float,
         help="Moving average alpha parameter, how much to add of the new observation.",
-        default=0.1,
+        default=0.10,
+    )
+
+    parser.add_argument(
+        "--neuron.negative_alpha",
+        type=float,
+        help="Moving average alpha parameter, how much to add of the new observation.",
+        default=0.03,
     )
 
     parser.add_argument(

--- a/folding/validators/reward.py
+++ b/folding/validators/reward.py
@@ -181,7 +181,7 @@ def get_energies(
                     < c.ANOMALY_THRESHOLD
                 ):
                     event["is_valid"][i] = False
-                    event["reason"][i] = "Energy difference too large"
+                    event["reason"][i] = "energy_difference_too_large"
                     continue
 
                 is_duplicate = any(


### PR DESCRIPTION
Validators are having a hard time to come to proper vtrust. This I due to two major reasons: 

1. There is a lot of noise / instability in the reward distributions because there are so many uids in the rewards calculation, and
2. Validators set weights at different times, so it could be that they are seeing slightly different windows of the rewards even though long term they have the right convergence. 

The first image below shows all the miner uids in the network and their relative performance. As you can see, there is a lot of variance in scoring. 
 
![original](https://github.com/user-attachments/assets/2e863ae3-e2a7-436c-b885-0de8c6a2127a)

We implement a new idea, an asymmetric reward function where you increase reward at the same rate, but lose reward at a lower rate, with `alpha = 0.03`, making the rate of loss `0.10/0.03 = 3.33x slower`. This is done via: 

```python
        # Matrix for alpha values
        scattered_alpha = torch.zeros_like(self.scores).to(self.device)

        for ii, uid in enumerate(uids_tensor):
            alpha = (
                self.config.neuron.positive_alpha
                if rewards[ii] > 0
                else self.config.neuron.negative_alpha
            )
            scattered_alpha[uid] = alpha

        # Update scores using exponential moving average
        self.scores: torch.FloatTensor = (
            scattered_alpha * scattered_rewards + (1 - scattered_alpha) * self.scores
        )
```

![new_rewards](https://github.com/user-attachments/assets/b6bad9b7-910a-4dc0-a292-9eab43cc1903)

A zoom in: 
![single_uid](https://github.com/user-attachments/assets/87b91800-5d9d-477d-a23c-109c30db9f0a)
