### PR TITLE
Refactor miner evaluation logic to remove evaluator from initial logs

### DIFF
--- a/folding/registries/miner_registry.py
+++ b/folding/registries/miner_registry.py
@@ -57,7 +57,6 @@ class MinerRegistry:
         initial_logs = {
             "can_process": False,
             "reported_energy": 0,
-            "evaluator": None,
             "seed": None,
             "files": {},
             "process_md_output_time": 0,

--- a/folding/validators/reward.py
+++ b/folding/validators/reward.py
@@ -141,6 +141,10 @@ async def run_evaluation_validation_pipeline(
     for uid, miner_data in sorted_dict.items():
         try:
             reported_energy = miner_data["reported_energy"]
+
+            if uid not in evaluators:
+                continue
+
             evaluator: BaseEvaluator = evaluators[uid]
 
             if reported_energy == 0:

--- a/folding/validators/reward.py
+++ b/folding/validators/reward.py
@@ -22,6 +22,7 @@ def evaluate(
     miner_registry: MinerRegistry,
 ):
     """Evaluates the miner's response and updates the miner registry."""
+    evaluators = {}
 
     for uid, resp in zip(uids, responses):
         miner_files = {}
@@ -66,7 +67,7 @@ def evaluate(
             miner_files["state_xml_path"] = (
                 evaluator.state_xml_path if hasattr(evaluator, "state_xml_path") else ""
             )
-            
+
             miner_files["trajectory_path"] = (
                 evaluator.trajectory_path
                 if hasattr(evaluator, "trajectory_path")
@@ -77,20 +78,20 @@ def evaluate(
             miner_registry.registry[uid].logs[
                 "reported_energy"
             ] = evaluator.get_reported_energy()
-            miner_registry.registry[uid].logs["evaluator"] = evaluator
             miner_registry.registry[uid].logs["seed"] = resp.miner_seed
             miner_registry.registry[uid].logs["files"] = miner_files
             miner_registry.registry[uid].logs["process_md_output_time"] = (
                 time.time() - start_time
             )
             miner_registry.registry[uid].logs["axon"] = resp.axon
+            evaluators[uid] = evaluator
 
         except Exception as e:
             # If any of the above methods have an error, we will catch here.
             logger.error(f"Failed to parse miner data for uid {uid} with error: {e}")
             continue
 
-    return miner_registry
+    return miner_registry, evaluators
 
 
 async def run_evaluation_validation_pipeline(
@@ -118,8 +119,13 @@ async def run_evaluation_validation_pipeline(
     energies = {uid: 0 for uid in uids}
 
     # Get initial evaluations
-    miner_registry = evaluate(
-        protein = protein, responses = responses, uids = uids, job_type = job_type, s3_handler = validator.handler, miner_registry = miner_registry
+    miner_registry, evaluators = evaluate(
+        protein=protein,
+        responses=responses,
+        uids=uids,
+        job_type=job_type,
+        s3_handler=validator.handler,
+        miner_registry=miner_registry,
     )
 
     all_miner_logs: Dict[int, Dict[str, Any]] = miner_registry.get_all_miner_logs()
@@ -135,7 +141,7 @@ async def run_evaluation_validation_pipeline(
     for uid, miner_data in sorted_dict.items():
         try:
             reported_energy = miner_data["reported_energy"]
-            evaluator: BaseEvaluator = miner_data["evaluator"]
+            evaluator: BaseEvaluator = evaluators[uid]
 
             if reported_energy == 0:
                 continue


### PR DESCRIPTION
When wandb is turned on, the valuator fails to get json serialized:
```
0|sn25_validator  | 2025-04-18 08:15:30.651 | SUCCESS | updated a wandb run
0|sn25_validator  | 2025-04-18 08:15:30.656 | ERROR | Error in update_jobs: Traceback (most recent call last):
0|sn25_validator  |   File "/root/folding/neurons/validator.py", line 636, in update_jobs
0|sn25_validator  |     await self.update_job(job=job)
0|sn25_validator  |   File "/root/folding/neurons/validator.py", line 478, in update_job
0|sn25_validator  |     log_event(
0|sn25_validator  |   File "/root/folding/folding/utils/logging.py", line 130, in log_event
0|sn25_validator  |     run.log(event)
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/site-packages/wandb/sdk/wandb_run.py", line 449, in wrapper
0|sn25_validator  |     return func(self, *args, **kwargs)
0|sn25_validator  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/site-packages/wandb/sdk/wandb_run.py", line 400, in wrapper_fn
0|sn25_validator  |     return func(self, *args, **kwargs)
0|sn25_validator  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/site-packages/wandb/sdk/wandb_run.py", line 390, in wrapper
0|sn25_validator  |     return func(self, *args, **kwargs)
0|sn25_validator  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/site-packages/wandb/sdk/wandb_run.py", line 1877, in log
0|sn25_validator  |     self._log(data=data, step=step, commit=commit)
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/site-packages/wandb/sdk/wandb_run.py", line 1641, in _log
0|sn25_validator  |     self._partial_history_callback(data, step, commit)
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/site-packages/wandb/sdk/wandb_run.py", line 1513, in _partial_history_callback
0|sn25_validator  |     self._backend.interface.publish_partial_history(
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/site-packages/wandb/sdk/interface/interface.py", line 612, in publish_partial_history
0|sn25_validator  |     item.value_json = json_dumps_safer_history(v)
0|sn25_validator  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/site-packages/wandb/util.py", line 842, in json_dumps_safer_history
0|sn25_validator  |     return dumps(obj, cls=WandBHistoryJSONEncoder, **kwargs)
0|sn25_validator  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/json/__init__.py", line 238, in dumps
0|sn25_validator  |     **kw).encode(obj)
0|sn25_validator  |           ^^^^^^^^^^^
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/json/encoder.py", line 200, in encode
0|sn25_validator  |     chunks = self.iterencode(o, _one_shot=True)
0|sn25_validator  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/json/encoder.py", line 258, in iterencode
0|sn25_validator  |     return _iterencode(o, 0)
0|sn25_validator  |            ^^^^^^^^^^^^^^^^^
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/site-packages/wandb/util.py", line 807, in default
0|sn25_validator  |     return json.JSONEncoder.default(self, obj)
0|sn25_validator  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
0|sn25_validator  |   File "/root/miniconda3/envs/folding/lib/python3.11/json/encoder.py", line 180, in default
0|sn25_validator  |     raise TypeError(f'Object of type {o.__class__.__name__} '
0|sn25_validator  | TypeError: Object of type SyntheticMDEvaluator is not JSON serializable
```