### PR TITLE
Refactor validation process to include trajectories

### DIFF
--- a/folding/miners/folding_miner.py
+++ b/folding/miners/folding_miner.py
@@ -922,9 +922,9 @@ class SimulationManager:
         }
 
         self.STATES = ["nvt", "npt", "md_0_1"]
-        self.CHECKPOINT_INTERVAL = 10000
-        self.TRAJECTORY_INTERVAL = 10000
-        self.STATE_DATA_REPORTER_INTERVAL = 10
+        self.CHECKPOINT_INTERVAL = self.system_config.save_interval_checkpoint
+        self.TRAJECTORY_INTERVAL = self.system_config.save_interval_trajectory
+        self.STATE_DATA_REPORTER_INTERVAL = self.system_config.save_interval_log
         self.EXIT_REPORTER_INTERVAL = 10
 
     def create_empty_file(self, file_path: str):

--- a/folding/utils/opemm_simulation_config.py
+++ b/folding/utils/opemm_simulation_config.py
@@ -26,6 +26,7 @@ class SimulationConfig(BaseModel):
     time_step_size: float = 0.002
     time_units: str = "picosecond"
     save_interval_checkpoint: int = 10000
+    save_interval_trajectory: int = 100
     save_interval_log: int = 10
     box_padding: float = 1.0
     friction: float = 1.0


### PR DESCRIPTION
- Made trajectories mandatory
- changed number_of_checkpoints calculation to be based off of final checkpoint step
- instead of using checkpoint step to determine the right log file section in is_checkpoint_valid we precalculate what the checkpoint should be based on our save interval
- added trajectory validation by reproducing trajectories and checking the RMSD of each frame between the miner trajectories and the checked trajectories
- Used saving intervals from the system configs in base miner