### PR TITLE
fix: correct typos 'occured' and 'recieved'

### DIFF
--- a/documentation/molecular_dynamics/validation.md
+++ b/documentation/molecular_dynamics/validation.md
@@ -20,7 +20,7 @@ Once the above procedure is done, the flow chart below outlines the rest of the 
     <img src="../../assets/validator_flow.png" alt="Validator-flow">
 </div>
 
-Once the miner has recieved the protein, the validator can query the miner at any frequency to obtain intermediate results from the miner. This is important for the following reasons:
+Once the miner has received the protein, the validator can query the miner at any frequency to obtain intermediate results from the miner. This is important for the following reasons:
 
 1. Miners are graded periodically. This means that if 10 miners were given this job, every miner has the opportunity to obtain rewards for their work, rather than the best final step being rewarded. 
 2. On each step, the validator **MUST** log the progress of their jobs over time for the set of hotkeys they have queried. Validators will record this information in a database called `protein_jobs.csv`, which is created automatically. Below is an example of the first few elements of the db. 

--- a/folding/base/organic_scoring_base.py
+++ b/folding/base/organic_scoring_base.py
@@ -69,7 +69,7 @@ class OrganicScoringBase(ABC):
 
             except Exception as e:
                 bt.logging.error(
-                    f"Error occured during organic scoring iteration:\n{e}"
+                    f"Error occurred during organic scoring iteration:\n{e}"
                 )
                 await asyncio.sleep(1)
 

--- a/folding/organic/validator.py
+++ b/folding/organic/validator.py
@@ -62,7 +62,7 @@ class OrganicValidator(OrganicScoringBase):
                 )
 
             except Exception as e:
-                logger.error(f"Error occured during organic scoring iteration:\n{e}")
+                logger.error(f"Error occurred during organic scoring iteration:\n{e}")
                 await asyncio.sleep(1)
 
     async def forward(self) -> dict[str, Any]:


### PR DESCRIPTION
Fix typos in error messages and documentation:

- occured → occurred (2 files)
- recieved → received (1 file)